### PR TITLE
[chore] use default secret for vercel

### DIFF
--- a/vercel/project-entity.yaml
+++ b/vercel/project-entity.yaml
@@ -3,9 +3,10 @@ namespace: vercel
 project:
   defines: entity
   schema:
-    required: ["secret_ref", "name"]
+    required: ["name"]
     secret_ref:
       type: string
+      default: default-vercel-token
     name:
       type: string
   lifecycle:

--- a/vercel/project-sync.js
+++ b/vercel/project-sync.js
@@ -82,6 +82,9 @@ function deleteProject(def, state) {
 
 
 function main(def, state, ctx) {
+    if (!def.secret_ref) {
+        def.secret_ref = "default-vercel-token";
+    }
     switch (ctx.action) {
         case "create":
             state = createProject(def)

--- a/vercel/vercel.yaml
+++ b/vercel/vercel.yaml
@@ -2,6 +2,8 @@ namespace: vercel
 
 deploy:
   defines: runnable
+  permitted-secrets:
+    default-vercel-token: true
   containers:
     deploy:
       image: monkimages.azurecr.io/example-vercel-build:latest
@@ -27,7 +29,7 @@ deploy:
     token:
       env: VERCEL_TOKEN
       type: string
-      value: example
+      value: <- secret("default-vercel-token")
     pre-deploy:
       type: string
       value: <- `echo "pre-deploy script"`


### PR DESCRIPTION
This pull request includes several changes to the `vercel` namespace to improve the handling of secret tokens and streamline the deployment process. The most important changes are grouped by theme below:

### Improvements to Secret Token Handling:

* [`vercel/project-entity.yaml`](diffhunk://#diff-272f7402728c48732100ff7b0681ec17e785a1d7f197692a283f85b345998c23L6-R9): Removed `secret_ref` from the required schema and added a default value for `secret_ref` as `default-vercel-token`.
* [`vercel/project-sync.js`](diffhunk://#diff-e6763c0dfa7a57e796a33ab4655d5177a300a0f73c2263b0a22e8a682b37ccd5R85-R87): Added a check in the `main` function to set `def.secret_ref` to `default-vercel-token` if it is not provided.

### Deployment Configuration Enhancements:

* [`vercel/vercel.yaml`](diffhunk://#diff-99468e5566d8d8383ea58577c0cbbe6615d61a5b6fdb423afdd23c772452a444R5-R6): Added `default-vercel-token` to the list of permitted secrets in the `deploy` configuration.
* [`vercel/vercel.yaml`](diffhunk://#diff-99468e5566d8d8383ea58577c0cbbe6615d61a5b6fdb423afdd23c772452a444L30-R32): Updated the `token` value in the `deploy` section to retrieve the value from the secret `default-vercel-token`.