### PR TITLE
[chore] add deploy dir var for netlify and vercel

### DIFF
--- a/netlify/netlify.yaml
+++ b/netlify/netlify.yaml
@@ -19,7 +19,7 @@ deploy:
       contents: |
         #!/bin/sh
         {{ v "pre-deploy" }}
-        netlify deploy --prod --dir=/home/node/app/build
+        netlify deploy --prod --dir=$DEPLOY_DIR
   variables:
     site-id:
       env: NETLIFY_SITE_ID
@@ -29,6 +29,10 @@ deploy:
       env: NETLIFY_AUTH_TOKEN
       type: string
       value: <- secret("default-netlify-pat")
+    deploy-dir:
+      env: DEPLOY_DIR
+      type: string
+      value: /home/node/app/
     pre-deploy:
       type: string
       value: <- `echo "pre-deploy script"`

--- a/vercel/vercel.yaml
+++ b/vercel/vercel.yaml
@@ -19,8 +19,8 @@ deploy:
       contents: |
         #!/bin/sh
         {{ v "pre-deploy" }}
-        vercel link --yes --project $VERCEL_PROJECT -t $VERCEL_TOKEN
-        vercel deploy --prod --public --yes -t $VERCEL_TOKEN
+        vercel link --cwd $DEPLOY_DIR --yes --project $VERCEL_PROJECT -t $VERCEL_TOKEN
+        vercel deploy --cwd $DEPLOY_DIR --prod --public --yes -t $VERCEL_TOKEN
   variables:
     project:
       env: VERCEL_PROJECT
@@ -30,6 +30,10 @@ deploy:
       env: VERCEL_TOKEN
       type: string
       value: <- secret("default-vercel-token")
+    deploy-dir:
+      env: DEPLOY_DIR
+      type: string
+      value: /home/node/app/
     pre-deploy:
       type: string
       value: <- `echo "pre-deploy script"`


### PR DESCRIPTION
This pull request includes changes to the deployment configurations for both Netlify and Vercel. The most important changes involve introducing a new environment variable for the deployment directory and updating the deployment commands to use this variable.

Updates to deployment configurations:

* [`netlify/netlify.yaml`](diffhunk://#diff-168991860e07e1e1cfff12b81f24bf8ab6f0a9c75d32ec347def8d2981ab49a8L22-R22): Changed the deployment directory in the `netlify deploy` command to use the `DEPLOY_DIR` environment variable. Added a new `deploy-dir` variable to set the `DEPLOY_DIR` environment variable. [[1]](diffhunk://#diff-168991860e07e1e1cfff12b81f24bf8ab6f0a9c75d32ec347def8d2981ab49a8L22-R22) [[2]](diffhunk://#diff-168991860e07e1e1cfff12b81f24bf8ab6f0a9c75d32ec347def8d2981ab49a8R32-R35)
* [`vercel/vercel.yaml`](diffhunk://#diff-99468e5566d8d8383ea58577c0cbbe6615d61a5b6fdb423afdd23c772452a444L22-R23): Updated the `vercel link` and `vercel deploy` commands to use the `DEPLOY_DIR` environment variable for the `--cwd` option. Added a new `deploy-dir` variable to set the `DEPLOY_DIR` environment variable. [[1]](diffhunk://#diff-99468e5566d8d8383ea58577c0cbbe6615d61a5b6fdb423afdd23c772452a444L22-R23) [[2]](diffhunk://#diff-99468e5566d8d8383ea58577c0cbbe6615d61a5b6fdb423afdd23c772452a444R33-R36)