### PR TITLE
[chore] add admin_url link to netlify

### DIFF
--- a/netlify/site-sync.js
+++ b/netlify/site-sync.js
@@ -20,7 +20,7 @@ function getSite(def) {
     resArr = JSON.parse(res.body);
     for (let i = 0; i < resArr.length; i++) {
         if (resArr[i].name === def.name) {
-            return {id: resArr[i].id, name: resArr[i].name, url: resArr[i].url};
+            return {id: resArr[i].id, name: resArr[i].name, url: resArr[i].url, admin_url: resArr[i].admin_url};
         }
     }
 
@@ -53,7 +53,7 @@ function createSite(def) {
 
     resObj = JSON.parse(res.body);
 
-    return {id: resObj.id, name: resObj.name, url: resObj.url};
+    return {id: resObj.id, name: resObj.name, url: resObj.url, admin_url: resObj.admin_url};
 }
 
 function updateSite(def, state) {


### PR DESCRIPTION
This pull request includes updates to the `netlify/site-sync.js` file to enhance the returned site object with additional information.

Enhancements to returned site object:

* [`netlify/site-sync.js`](diffhunk://#diff-c3ee40d3056fbae70f43ac8382bf2ebf087b8620f2f9784326da37ecd32e2bd1L23-R23): Modified the `getSite` function to include the `admin_url` in the returned site object.
* [`netlify/site-sync.js`](diffhunk://#diff-c3ee40d3056fbae70f43ac8382bf2ebf087b8620f2f9784326da37ecd32e2bd1L56-R56): Modified the `createSite` function to include the `admin_url` in the returned site object.