### PR TITLE
[chore] add team slug param for netlify

### DIFF
--- a/netlify/site-entity.yaml
+++ b/netlify/site-entity.yaml
@@ -11,6 +11,8 @@ site:
       default: default-netlify-pat
     name:
       type: string
+    team_slug:
+      type: string
     password:
       type: string
     custom_domain:

--- a/netlify/site-sync.js
+++ b/netlify/site-sync.js
@@ -6,7 +6,12 @@ const BASE_URL = "https://api.netlify.com/api/v1";
 function getSite(def) {
     const token = secret.get(def.secret_ref);
 
-    let res = http.get(BASE_URL + "/sites?name=" + def.name,
+    let url_prefix = "";
+    if (def.team_slug) {
+        url_prefix = "/" + def.team_slug;
+    }
+
+    let res = http.get(BASE_URL + url_prefix + "/sites?name=" + def.name,
         {
             headers: {
                 "authorization": "Bearer " + token,
@@ -38,7 +43,12 @@ function createSite(def) {
         created_via: "monk.io"
     };
 
-    let res = http.post(BASE_URL + "/sites",
+    let url_prefix = "";
+    if (def.team_slug) {
+        url_prefix = "/" + def.team_slug;
+    }
+
+    let res = http.post(BASE_URL + url_prefix + "/sites",
         {
             headers: {
                 "authorization": "Bearer " + token,


### PR DESCRIPTION
This pull request introduces changes to the Netlify site synchronization functionality, specifically adding support for team-specific site management. The most important changes include adding a new `team_slug` property to the site entity schema and updating the site synchronization logic to handle this new property.

Schema updates:

* [`netlify/site-entity.yaml`](diffhunk://#diff-e80c30c6d77cf3af6af73435c39cf91cc572eafe7747e6b816949ef3ad98b404R14-R15): Added a new `team_slug` property to the site entity schema to support team-specific site management.

Site synchronization logic updates:

* [`netlify/site-sync.js`](diffhunk://#diff-c3ee40d3056fbae70f43ac8382bf2ebf087b8620f2f9784326da37ecd32e2bd1L9-R14): Updated the `getSite` function to include the `team_slug` in the URL if it is provided.
* [`netlify/site-sync.js`](diffhunk://#diff-c3ee40d3056fbae70f43ac8382bf2ebf087b8620f2f9784326da37ecd32e2bd1L41-R51): Updated the `createSite` function to include the `team_slug` in the URL if it is provided.