### PR TITLE
[chore] use variable node version for netlify deploy

### DIFF
--- a/netlify/Dockerfile
+++ b/netlify/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:18-alpine
+ARG NODE_VERSION=18
+FROM node:${NODE_VERSION}-alpine3.21
 
 RUN npm install netlify-cli -g
 

--- a/netlify/netlify.yaml
+++ b/netlify/netlify.yaml
@@ -6,7 +6,7 @@ deploy:
     default-netlify-pat: true
   containers:
     deploy:
-      image: monkimages.azurecr.io/example-netlify-build:latest
+      image: <- `monkimages.azurecr.io/netlify-build:${node-version}`
       restart: no
       bash: /tmp/init.sh
 #      paths:
@@ -21,6 +21,10 @@ deploy:
         {{ v "pre-deploy" }}
         netlify deploy --prod --dir=$DEPLOY_DIR
   variables:
+    node-version:
+      env: NODE_VERSION
+      type: string
+      value: 18 # one of 18, 20, 22, 23
     site-id:
       env: NETLIFY_SITE_ID
       type: string


### PR DESCRIPTION
This pull request includes updates to the Netlify deployment configuration to make the Node.js version more flexible and configurable. The most important changes involve modifying the Dockerfile to use an argument for the Node.js version and updating the Netlify configuration to support this new setup.

### Dockerfile and Configuration Updates:

* [`netlify/Dockerfile`](diffhunk://#diff-80b3643ca7b96c29adb498830dbdc518146058319bebc821831d84e84e8e22c9L1-R2): Changed the base image to use an argument for the Node.js version, allowing for more flexibility in specifying the version.
* [`netlify/netlify.yaml`](diffhunk://#diff-168991860e07e1e1cfff12b81f24bf8ab6f0a9c75d32ec347def8d2981ab49a8L9-R9): Updated the `deploy` container image to use the `node-version` variable, making the Node.js version configurable.
* [`netlify/netlify.yaml`](diffhunk://#diff-168991860e07e1e1cfff12b81f24bf8ab6f0a9c75d32ec347def8d2981ab49a8R24-R27): Added a new variable `node-version` to the `variables` section, enabling the specification of different Node.js versions.