### PR TITLE
[chore] create netlify/vercel entity on update if id is empty

### DIFF
--- a/netlify/site-sync.js
+++ b/netlify/site-sync.js
@@ -108,6 +108,9 @@ function main(def, state, ctx) {
     if (!def.secret_ref) {
         def.secret_ref = "default-netlify-pat";
     }
+    if (ctx.action === "update" && !state.id) {
+        ctx.action = "create";
+    }
     switch (ctx.action) {
         case "create":
             const ex = getSite(def);

--- a/vercel/project-sync.js
+++ b/vercel/project-sync.js
@@ -112,6 +112,9 @@ function main(def, state, ctx) {
     if (!def.secret_ref) {
         def.secret_ref = "default-vercel-token";
     }
+    if (ctx.action === "update" && !state.id) {
+        ctx.action = "create";
+    }
     switch (ctx.action) {
         case "create":
             try {


### PR DESCRIPTION
This pull request includes changes to ensure that the `ctx.action` is set to "create" when the action is "update" but no `state.id` is present. This adjustment is made in both the `netlify/site-sync.js` and `vercel/project-sync.js` files.

Changes include:

* [`netlify/site-sync.js`](diffhunk://#diff-c3ee40d3056fbae70f43ac8382bf2ebf087b8620f2f9784326da37ecd32e2bd1R111-R113): Added a check to set `ctx.action` to "create" if `ctx.action` is "update" and `state.id` is not present.
* [`vercel/project-sync.js`](diffhunk://#diff-e6763c0dfa7a57e796a33ab4655d5177a300a0f73c2263b0a22e8a682b37ccd5R115-R117): Added a similar check to set `ctx.action` to "create" if `ctx.action` is "update" and `state.id` is not present.