### PR TITLE
Split public endpoint

### DIFF
--- a/redis-cloud/database-sync.js
+++ b/redis-cloud/database-sync.js
@@ -315,7 +315,10 @@ function checkReadiness(def, state) {
 
     const resObj = JSON.parse(res.body);
     if (resObj.status === "active") {
+        const publicEndpoint = resObj.publicEndpoint.split(":");
         state.publicEndpoint = resObj.publicEndpoint
+        state.publicEndpointHost = publicEndpoint[0]
+        state.publicEndpointPort = publicEndpoint[1]
         state.ready = true;
         return state;
     }

--- a/redis-cloud/example.yaml
+++ b/redis-cloud/example.yaml
@@ -86,6 +86,14 @@ redis-client:
       env: DB_ADDR
       value: <- connection-target("redis-cloud-db") entity-state get-member("publicEndpoint")
       type: string
+    redis_cloud_db_host:
+      env: DB_HOST
+      value: <- connection-target("redis-cloud-db") entity-state get-member("publicEndpointHost")
+      type: string
+    redis_cloud_db_port:
+      env: DB_PORT
+      value: <- connection-target("redis-cloud-db") entity-state get-member("publicEndpointPort")
+      type: string
     image-tag:
       value: latest
       type: string


### PR DESCRIPTION
This pull request introduces changes to enhance the handling of Redis Cloud database connection details by splitting the `publicEndpoint` into host and port components. These changes improve clarity and flexibility in managing connection configurations.

### Enhancements to Redis Cloud connection handling:

* [`redis-cloud/database-sync.js`](diffhunk://#diff-ca77d031d18ede20c5c2bdfebe922cdc87e0c7cd8850d13d56e8a2ad93511133R318-R321): Updated the `checkReadiness` function to parse the `publicEndpoint` into `publicEndpointHost` and `publicEndpointPort` and store them separately in the `state` object. This ensures better separation of concerns and facilitates easier access to individual connection components.

* [`redis-cloud/example.yaml`](diffhunk://#diff-ef40109c716d88ff38729adab01353d4a295f03507e6543578f7dd5d42130242R89-R96): Added new environment variables `DB_HOST` and `DB_PORT` to store the `publicEndpointHost` and `publicEndpointPort`, respectively. These variables are populated using the corresponding values from the entity state, enabling more granular control over connection information in deployment configurations.