### PR TITLE
[chore] use ssl_url from netlify site response

### DIFF
--- a/netlify/site-sync.js
+++ b/netlify/site-sync.js
@@ -25,7 +25,7 @@ function getSite(def) {
     resArr = JSON.parse(res.body);
     for (let i = 0; i < resArr.length; i++) {
         if (resArr[i].name === def.name) {
-            return {id: resArr[i].id, name: resArr[i].name, url: resArr[i].url, admin_url: resArr[i].admin_url};
+            return {id: resArr[i].id, name: resArr[i].name, url: resArr[i].ssl_url, admin_url: resArr[i].admin_url};
         }
     }
 
@@ -63,7 +63,7 @@ function createSite(def) {
 
     resObj = JSON.parse(res.body);
 
-    return {id: resObj.id, name: resObj.name, url: resObj.url, admin_url: resObj.admin_url};
+    return {id: resObj.id, name: resObj.name, url: resObj.ssl_url, admin_url: resObj.admin_url};
 }
 
 function updateSite(def, state) {


### PR DESCRIPTION
This pull request updates the `netlify/site-sync.js` file to ensure that the `ssl_url` property is used instead of the `url` property when returning site information. This change improves the handling of secure URLs.

Updates to site URL handling:

* [`function getSite(def)`](diffhunk://#diff-c3ee40d3056fbae70f43ac8382bf2ebf087b8620f2f9784326da37ecd32e2bd1L28-R28): Modified the returned object to use `ssl_url` instead of `url` for the site's URL property.
* [`function createSite(def)`](diffhunk://#diff-c3ee40d3056fbae70f43ac8382bf2ebf087b8620f2f9784326da37ecd32e2bd1L66-R66): Updated the returned object to replace the `url` property with `ssl_url` for consistency and secure URL usage.