### PR TITLE
[chore] check mongo token hash before use

### DIFF
--- a/dist/mongodb-atlas/MANIFEST
+++ b/dist/mongodb-atlas/MANIFEST
@@ -1,3 +1,3 @@
 REPO mongodb-atlas
-LOAD project.yaml common.yaml base.yaml user.yaml cluster.yaml
-RESOURCES base.js cluster-sync.js project-sync.js user-sync.js common.js
+LOAD cluster.yaml project.yaml user.yaml common.yaml base.yaml
+RESOURCES cluster-sync.js project-sync.js user-sync.js base.js common.js

--- a/dist/mongodb-atlas/common.js
+++ b/dist/mongodb-atlas/common.js
@@ -39,6 +39,7 @@ __export(common_exports, {
 module.exports = __toCommonJS(common_exports);
 var import_http = __toESM(require("http"));
 var import_secret = __toESM(require("secret"));
+var import_crypto = __toESM(require("crypto"));
 var BASE_URL = "https://cloud.mongodb.com/api/atlas/v2";
 var API_VERSION = "application/vnd.atlas.2023-01-01+json";
 var API_VERSION_2025 = "application/vnd.atlas.2025-03-12+json";
@@ -46,18 +47,15 @@ function getToken(secretRef) {
   const now = /* @__PURE__ */ new Date();
   let cachedToken;
   let cachedTokenExpires;
+  let cachedSecretHash;
   try {
     cachedToken = import_secret.default.get(secretRef + "_cached_token");
     cachedTokenExpires = import_secret.default.get(secretRef + "_cached_token_expires");
+    cachedSecretHash = import_secret.default.get(secretRef + "_cached_secret_hash");
   } catch (e) {
     cachedToken = void 0;
     cachedTokenExpires = void 0;
-  }
-  if (cachedToken && cachedTokenExpires) {
-    const expires = new Date(cachedTokenExpires);
-    if (now < expires) {
-      return cachedToken;
-    }
+    cachedSecretHash = void 0;
   }
   const serviceAccountToken = import_secret.default.get(secretRef);
   if (!serviceAccountToken) {
@@ -65,6 +63,13 @@ function getToken(secretRef) {
   }
   if (!serviceAccountToken.startsWith("mdb_sa_id")) {
     throw new Error("Token is not a service account token");
+  }
+  const currentSecretHash = import_crypto.default.sha256(serviceAccountToken);
+  if (cachedToken && cachedTokenExpires && cachedSecretHash) {
+    const expires = new Date(cachedTokenExpires);
+    if (now < expires && cachedSecretHash === currentSecretHash) {
+      return cachedToken;
+    }
   }
   const headers = {
     "Accept": "application/json",
@@ -90,6 +95,7 @@ function getToken(secretRef) {
     const expiresIn = new Date(now.getTime() + tokenResponse.expires_in * 1e3);
     import_secret.default.set(secretRef + "_cached_token", tokenResponse.access_token);
     import_secret.default.set(secretRef + "_cached_token_expires", expiresIn.toISOString());
+    import_secret.default.set(secretRef + "_cached_secret_hash", currentSecretHash);
   }
   return tokenResponse.access_token;
 }

--- a/dist/monkec/MANIFEST
+++ b/dist/monkec/MANIFEST
@@ -1,3 +1,3 @@
 REPO monkec
-LOAD http-client.yaml base.yaml
+LOAD base.yaml http-client.yaml
 RESOURCES base.js http-client.js

--- a/dist/neon/MANIFEST
+++ b/dist/neon/MANIFEST
@@ -1,3 +1,3 @@
 REPO neon
-LOAD role.yaml project.yaml common.yaml neon-base.yaml branch.yaml database.yaml compute.yaml
-RESOURCES role-sync.js neon-base.js database-sync.js project-sync.js common.js branch-sync.js compute-sync.js
+LOAD branch.yaml compute.yaml database.yaml project.yaml role.yaml common.yaml neon-base.yaml
+RESOURCES branch-sync.js compute-sync.js database-sync.js project-sync.js role-sync.js common.js neon-base.js

--- a/dist/netlify/MANIFEST
+++ b/dist/netlify/MANIFEST
@@ -1,3 +1,3 @@
 REPO netlify
-LOAD netlify-base.yaml form.yaml common.yaml site.yaml deploy.yaml account.yaml
-RESOURCES common.js netlify-base.js account-sync.js form-sync.js site-sync.js deploy-sync.js
+LOAD account.yaml form.yaml site.yaml netlify-base.yaml common.yaml deploy.yaml
+RESOURCES account-sync.js form-sync.js site-sync.js netlify-base.js common.js deploy-sync.js

--- a/src/lib/builtins/crypto.d.ts
+++ b/src/lib/builtins/crypto.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Crypto module for cryptographic operations (provided by Goja runtime)
+ */
+declare module "crypto" {
+  /**
+   * Crypto interface
+   */
+  interface CryptoModule {
+    /**
+     * Creates a SHA256 hash of the input string
+     * @param input - The string to hash
+     * @returns The SHA256 hash as a hexadecimal string
+     */
+    sha256(input: string): string;
+  }
+
+  const crypto: CryptoModule;
+  export default crypto;
+}

--- a/src/lib/builtins/index.d.ts
+++ b/src/lib/builtins/index.d.ts
@@ -10,6 +10,7 @@
 /// <reference path="./cli.d.ts" />
 /// <reference path="./parser.d.ts" />
 /// <reference path="./helpers.d.ts" />
+/// <reference path="./crypto.d.ts" />
 
 // Note: Cloud provider modules (aws, gcp, azure, digitalocean) are intentionally
 // left out for now but can be added later as separate files following the same pattern


### PR DESCRIPTION
This pull request enhances the `getToken` function in the `src/mongodb-atlas/common.ts` file by introducing a mechanism to invalidate the token cache when the associated secret changes. The changes also add the `crypto` module to compute a SHA256 hash for this purpose. Below are the most important changes:

### Token caching improvements:
* Added a SHA256 hash calculation for the secret using the `crypto` module to detect changes in the secret. This ensures that cached tokens are invalidated when the secret changes. (`[[1]](diffhunk://#diff-71fcb5edb1ebee2d3793d1e3bee9528650cae632ee15be168523224c44bb47bbR3)`, `[[2]](diffhunk://#diff-71fcb5edb1ebee2d3793d1e3bee9528650cae632ee15be168523224c44bb47bbR41-R51)`)
* Updated the caching logic to store and validate the secret hash alongside the token and its expiration. Tokens are now only reused if the secret hash matches the current secret. (`[[1]](diffhunk://#diff-71fcb5edb1ebee2d3793d1e3bee9528650cae632ee15be168523224c44bb47bbR12-R28)`, `[[2]](diffhunk://#diff-71fcb5edb1ebee2d3793d1e3bee9528650cae632ee15be168523224c44bb47bbR41-R51)`)

### Code updates for caching:
* Modified the token caching mechanism to include the secret hash in the cache. This ensures that the secret hash is stored and retrieved along with the token and expiration. (`[src/mongodb-atlas/common.tsL70-R83](diffhunk://#diff-71fcb5edb1ebee2d3793d1e3bee9528650cae632ee15be168523224c44bb47bbL70-R83)`)