### PR TITLE
[chore] add auth0 app state.issuer property with auth domain

### DIFF
--- a/auth0/auth-sync.js
+++ b/auth0/auth-sync.js
@@ -235,6 +235,7 @@ function syncApplication(def, state, update) {
 
   return {
     ready: true,
+    "issuer": `${def.domain}`,
     "client-id": appObj.client_id,
     name: appObj.name,
     "client-secret": appObj.client_secret,
@@ -400,6 +401,7 @@ function patchApplication(def, state, ctx) {
 
   return {
     ready: true,
+    "issuer": `${def.domain}`,
     "client-id": appObj.client_id,
     name: appObj.name,
     "client-secret": appObj.client_secret,


### PR DESCRIPTION
This pull request introduces a minor enhancement to the `auth0/auth-sync.js` file by adding an `issuer` field to the return objects of two functions, `syncApplication` and `patchApplication`. This change ensures that the `issuer` field is consistently included in the application synchronization and patching processes.

Key changes:

* Added an `"issuer"` field to the return object of the `syncApplication` function, using the value `${def.domain}`. (`[auth0/auth-sync.jsR238](diffhunk://#diff-1354fbb553501163afb6b8f8ba88b2eaaab3bc4d79333df136719e2925a5d06bR238)`)
* Added an `"issuer"` field to the return object of the `patchApplication` function, using the value `${def.domain}`. (`[auth0/auth-sync.jsR404](diffhunk://#diff-1354fbb553501163afb6b8f8ba88b2eaaab3bc4d79333df136719e2925a5d06bR404)`)