### PR TITLE
rename database runnable in digital ocean

### DIFF
--- a/dist/digitalocean-agent/agent-sync.js
+++ b/dist/digitalocean-agent/agent-sync.js
@@ -263,7 +263,6 @@ var _Agent = class _Agent extends (_a = MonkecBase.MonkEntity, _get_dec = [actio
     if (!this.state.id) return false;
     try {
       const data = this.httpGet(`/v2/gen-ai/agents/${this.state.id}`);
-      console.log("checkReadiness", JSON.stringify(data));
       const agent = data.agent || data || {};
       const deployment = agent.deployment || {};
       const rawStatus = deployment.status || agent.status || agent.state || "";
@@ -282,7 +281,6 @@ var _Agent = class _Agent extends (_a = MonkecBase.MonkEntity, _get_dec = [actio
       }
       if (endpoint) this.state.endpoint = endpoint;
       this.state.status = status;
-      console.log("checkReadiness", status, endpoint);
       return ["active", "ready", "running", "enabled"].includes(status);
     } catch (_e) {
       return false;

--- a/dist/digitalocean-database/MANIFEST
+++ b/dist/digitalocean-database/MANIFEST
@@ -1,5 +1,5 @@
 REPO digitalocean-database
-digital-ocean-database: database.ts
+database: database.ts
 api-token: api-token.ts
-LOAD digital-ocean-database.yaml api-token.yaml common.yaml do-provider-base.yaml digitalocean-base.yaml
-RESOURCES do-provider-base.js common.js api-token-sync.js digitalocean-base.js digital-ocean-database-sync.js
+LOAD api-token.yaml common.yaml do-provider-base.yaml digitalocean-base.yaml digital-ocean-database.yaml
+RESOURCES digital-ocean-database-sync.js do-provider-base.js digitalocean-base.js api-token-sync.js common.js

--- a/dist/digitalocean-database/digital-ocean-database.yaml
+++ b/dist/digitalocean-database/digital-ocean-database.yaml
@@ -1,5 +1,5 @@
 namespace: digitalocean-database
-digital-ocean-database:
+database:
   defines: entity
   metadata:
     name: DigitalOceanDatabase

--- a/src/digitalocean-database/MANIFEST
+++ b/src/digitalocean-database/MANIFEST
@@ -1,2 +1,2 @@
-digital-ocean-database: database.ts
+database: database.ts
 api-token: api-token.ts

--- a/src/digitalocean-database/README.md
+++ b/src/digitalocean-database/README.md
@@ -73,7 +73,7 @@ This directory contains a TypeScript entity for managing DigitalOcean Database c
 namespace: my-app
 
 my-postgres:
-  defines: digitalocean-database/digital-ocean-database
+  defines: digitalocean-database/database
   name: my-postgres-db
   engine: pg
   version: "16"
@@ -88,7 +88,7 @@ my-postgres:
 namespace: my-app
 
 my-mysql-cluster:
-  defines: digitalocean-database/digital-ocean-database
+  defines: digitalocean-database/database
   name: production-mysql
   engine: mysql
   version: "8.0"
@@ -109,7 +109,7 @@ my-mysql-cluster:
 namespace: my-app
 
 my-redis:
-  defines: digitalocean-database/digital-ocean-database
+  defines: digitalocean-database/database
   name: app-cache
   engine: redis
   version: "7"
@@ -128,7 +128,7 @@ If you prefer to manage API tokens manually instead of using the provider:
 namespace: my-app
 
 my-postgres-manual:
-  defines: digitalocean-database/digital-ocean-database
+  defines: digitalocean-database/database
   api_token_secret_ref: my-custom-do-token
   name: my-postgres-manual
   engine: pg
@@ -315,7 +315,7 @@ If you're upgrading from the previous version:
    ```yaml
    # Old (v1.x)
    my-db:
-     defines: digitalocean-database/digital-ocean-database
+     defines: digitalocean-database/database
      secret_ref: digitalocean-api-key
      permitted-secrets:
        digitalocean-api-key: true
@@ -323,7 +323,7 @@ If you're upgrading from the previous version:
    
    # New (v2.0)
    my-db:
-     defines: digitalocean-database/digital-ocean-database
+     defines: digitalocean-database/database
      # ... other config (no secrets needed!)
    ```
 

--- a/src/digitalocean-database/database.ts
+++ b/src/digitalocean-database/database.ts
@@ -14,7 +14,7 @@ import cli from "cli";
 /**
  * Defines the immutable configuration properties for a DigitalOcean Database entity.
  */
-export interface DigitalOceanDatabaseDefinition extends DOProviderDefinitionBase {
+export interface DatabaseDefinition extends DOProviderDefinitionBase {
     /**
      * Database cluster name
      * @description Name of the database cluster (3-63 characters, alphanumeric and hyphens only)
@@ -147,7 +147,7 @@ export interface DigitalOceanDatabaseState extends DOProviderStateBase {
  * including creation, updates, deletion, and monitoring operations.
  */
 export class DigitalOceanDatabase extends DOProviderEntity<
-    DigitalOceanDatabaseDefinition,
+    DatabaseDefinition,
     DigitalOceanDatabaseState
 > {
 

--- a/src/digitalocean-database/example.yaml
+++ b/src/digitalocean-database/example.yaml
@@ -2,8 +2,7 @@ namespace: digitalocean-database-example
 
 # Basic PostgreSQL database cluster
 my-postgres-db:
-  defines: digitalocean-database/digital-ocean-database
-  secret_ref: digitalocean-api-key
+  defines: digitalocean-database/database
   name: my-postgres-cluster
   engine: pg
   version: "16"
@@ -13,13 +12,10 @@ my-postgres-db:
   tags:
     - environment:production
     - application:my-app
-  permitted-secrets:
-    digitalocean-api-key: true
 
 # MySQL database cluster with multiple nodes
 my-mysql-cluster:
-  defines: digitalocean-database/digital-ocean-database
-  secret_ref: digitalocean-api-key
+  defines: digitalocean-database/database
   name: my-mysql-cluster
   engine: mysql
   version: "8.0"
@@ -32,13 +28,10 @@ my-mysql-cluster:
   db_config:
     sql_mode: "STRICT_TRANS_TABLES,NO_ZERO_DATE,NO_ZERO_IN_DATE,ERROR_FOR_DIVISION_BY_ZERO"
     default_time_zone: "UTC"
-  permitted-secrets:
-    digitalocean-api-key: true
 
 # Redis cache cluster
 my-redis-cache:
-  defines: digitalocean-database/digital-ocean-database
-  secret_ref: digitalocean-api-key
+  defines: digitalocean-database/database
   name: my-redis-cache
   engine: redis
   version: "7"
@@ -50,13 +43,10 @@ my-redis-cache:
     - application:cache
   db_config:
     redis_maxmemory_policy: "allkeys-lru"
-  permitted-secrets:
-    digitalocean-api-key: true
 
 # MongoDB cluster
 my-mongodb:
-  defines: digitalocean-database/digital-ocean-database
-  secret_ref: digitalocean-api-key
+  defines: digitalocean-database/database
   name: my-mongodb-cluster
   engine: mongodb
   version: "7.0"
@@ -66,5 +56,3 @@ my-mongodb:
   tags:
     - environment:production
     - application:document-store
-  permitted-secrets:
-    digitalocean-api-key: true


### PR DESCRIPTION
This pull request updates the DigitalOcean Database provider to use a simplified and more consistent naming convention across the codebase, documentation, and examples. The main focus is renaming the entity from `digital-ocean-database` to `database`, and updating the related interface names for clarity. Documentation and example configurations have also been revised to reflect these changes and to simplify secret management.

**Naming and Interface Updates:**
- Renamed the exported interface from `DigitalOceanDatabaseDefinition` to `DatabaseDefinition` in `database.ts`, and updated all usages accordingly. [[1]](diffhunk://#diff-3ebef185a4a4043e8fa60188fd96b44391351f05a905f8cc0fd002626093db36L17-R17) [[2]](diffhunk://#diff-3ebef185a4a4043e8fa60188fd96b44391351f05a905f8cc0fd002626093db36L150-R150)
- Changed the manifest entry from `digital-ocean-database` to `database` in `MANIFEST`.

**Documentation Updates:**
- Updated all references in `README.md` to use `digitalocean-database/database` instead of `digitalocean-database/digital-ocean-database` in configuration examples and migration instructions. [[1]](diffhunk://#diff-eb4030925c95b79f5f9fa1f0555358c013a8fb77b72e6c274b8ce13452fb5e5aL76-R76) [[2]](diffhunk://#diff-eb4030925c95b79f5f9fa1f0555358c013a8fb77b72e6c274b8ce13452fb5e5aL91-R91) [[3]](diffhunk://#diff-eb4030925c95b79f5f9fa1f0555358c013a8fb77b72e6c274b8ce13452fb5e5aL112-R112) [[4]](diffhunk://#diff-eb4030925c95b79f5f9fa1f0555358c013a8fb77b72e6c274b8ce13452fb5e5aL131-R131) [[5]](diffhunk://#diff-eb4030925c95b79f5f9fa1f0555358c013a8fb77b72e6c274b8ce13452fb5e5aL318-R326)

**Example Configuration Updates:**
- Updated `example.yaml` to use the new `database` entity name in all resource definitions, removing references to the old name. [[1]](diffhunk://#diff-401f9213e66459dd93eb4417375f3530ee29f65ceeea35bd97b141a82040cf66L5-R5) [[2]](diffhunk://#diff-401f9213e66459dd93eb4417375f3530ee29f65ceeea35bd97b141a82040cf66L16-R18) [[3]](diffhunk://#diff-401f9213e66459dd93eb4417375f3530ee29f65ceeea35bd97b141a82040cf66L35-R34) [[4]](diffhunk://#diff-401f9213e66459dd93eb4417375f3530ee29f65ceeea35bd97b141a82040cf66L53-R49) [[5]](diffhunk://#diff-401f9213e66459dd93eb4417375f3530ee29f65ceeea35bd97b141a82040cf66L69-L70)
- Simplified example configurations by removing unnecessary secret references and permitted-secrets blocks, reflecting the new authentication approach. [[1]](diffhunk://#diff-401f9213e66459dd93eb4417375f3530ee29f65ceeea35bd97b141a82040cf66L16-R18) [[2]](diffhunk://#diff-401f9213e66459dd93eb4417375f3530ee29f65ceeea35bd97b141a82040cf66L35-R34) [[3]](diffhunk://#diff-401f9213e66459dd93eb4417375f3530ee29f65ceeea35bd97b141a82040cf66L53-R49) [[4]](diffhunk://#diff-401f9213e66459dd93eb4417375f3530ee29f65ceeea35bd97b141a82040cf66L69-L70)