### PR TITLE
[chore] add cli.output when we skip updating entity

### DIFF
--- a/dist/mongodb-atlas/MANIFEST
+++ b/dist/mongodb-atlas/MANIFEST
@@ -1,4 +1,4 @@
 REPO mongodb-atlas
 VERSION_HASH 4d03df7a14e9
-LOAD user.yaml cluster.yaml base.yaml common.yaml project.yaml
-RESOURCES common.js project-sync.js base.js user-sync.js cluster-sync.js
+LOAD base.yaml cluster.yaml common.yaml project.yaml user.yaml
+RESOURCES cluster-sync.js project-sync.js user-sync.js common.js base.js

--- a/dist/monkec/MANIFEST
+++ b/dist/monkec/MANIFEST
@@ -1,5 +1,5 @@
 REPO monkec
-VERSION_HASH 89d1afcd8c1e
+VERSION_HASH 1e31de784c59
 VERSION 0.1.0
-LOAD http-client.yaml base.yaml
-RESOURCES base.js http-client.js
+LOAD base.yaml http-client.yaml
+RESOURCES http-client.js base.js

--- a/dist/monkec/base.js
+++ b/dist/monkec/base.js
@@ -37,6 +37,7 @@ __export(base_exports, {
 });
 module.exports = __toCommonJS(base_exports);
 var import_crypto = __toESM(require("crypto"));
+var import_cli = __toESM(require("cli"));
 var ACTION_METADATA_KEY = Symbol("monk:actions");
 function camelToKebab(str) {
   return str.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase();
@@ -146,7 +147,7 @@ var MonkEntity = class _MonkEntity {
             const currentHash = this.computeDefinitionHash();
             const previousHash = this.state.definition_hash;
             if (previousHash && previousHash === currentHash) {
-              console.log("No definition changes detected; skipping update");
+              import_cli.default.output("No changes detected for " + this.path + ": skipping update");
               return true;
             }
             this.update();

--- a/dist/monkec/base.yaml
+++ b/dist/monkec/base.yaml
@@ -4,5 +4,5 @@ base:
   defines: module
   metadata:
     version: 0.1.0
-    version-hash: 89d1afcd8c1e
+    version-hash: 1e31de784c59
   source: <<< base.js

--- a/dist/monkec/http-client.yaml
+++ b/dist/monkec/http-client.yaml
@@ -4,5 +4,5 @@ http-client:
   defines: module
   metadata:
     version: 0.1.0
-    version-hash: 89d1afcd8c1e
+    version-hash: 1e31de784c59
   source: <<< http-client.js

--- a/src/monkec/base.ts
+++ b/src/monkec/base.ts
@@ -1,4 +1,5 @@
 import crypto from "crypto";
+import cli from "cli";
 
 const BuiltinActions = [
     "create",
@@ -188,7 +189,7 @@ export abstract class MonkEntity<D extends object, S extends object> {
                         const previousHash = (this.state as any).definition_hash as string | undefined;
                         if (previousHash && previousHash === currentHash) {
                             // No changes; skip subclass update
-                            console.log("No definition changes detected; skipping update");
+                            cli.output("No changes detected for " + this.path + ": skipping update");
                             return true;
                         }
                         // Run subclass update and then persist new hash


### PR DESCRIPTION
This pull request introduces a small update to the `src/monkec/base.ts` file, replacing direct `console.log` usage with the `cli` library for output, and updating the message format for skipped updates.

- Logging improvements:
  * Imported the `cli` library and replaced `console.log` with `cli.output` for consistent command-line messaging when no changes are detected during subclass update. [[1]](diffhunk://#diff-1db0c1d7f6dff3c4849c2e649ac92affbbcd5e0216813d3ad714284282e36fe0R2) [[2]](diffhunk://#diff-1db0c1d7f6dff3c4849c2e649ac92affbbcd5e0216813d3ad714284282e36fe0L191-R192)