### PR TITLE
[chore] update dns management for cf entity, add working examples

### DIFF
--- a/dist/cloudflare/MANIFEST
+++ b/dist/cloudflare/MANIFEST
@@ -1,4 +1,4 @@
 REPO cloudflare
-VERSION_HASH 9ad7d46140b1
-LOAD cloudflare-dns-record.yaml cloudflare-base.yaml cloudflare-dns-zone.yaml
+VERSION_HASH e0206fa9d712
+LOAD cloudflare-base.yaml cloudflare-dns-record.yaml cloudflare-dns-zone.yaml
 RESOURCES cloudflare-base.js cloudflare-dns-record-sync.js cloudflare-dns-zone-sync.js

--- a/dist/cloudflare/cloudflare-base.yaml
+++ b/dist/cloudflare/cloudflare-base.yaml
@@ -3,5 +3,5 @@ namespace: cloudflare
 cloudflare-base:
   defines: module
   metadata:
-    version-hash: 9ad7d46140b1
+    version-hash: e0206fa9d712
   source: <<< cloudflare-base.js

--- a/dist/cloudflare/cloudflare-dns-record.yaml
+++ b/dist/cloudflare/cloudflare-dns-record.yaml
@@ -3,7 +3,7 @@ cloudflare-dns-record:
   defines: entity
   metadata:
     name: CloudflareDNSRecord
-    version-hash: 9ad7d46140b1
+    version-hash: e0206fa9d712
   schema:
     secret_ref:
       type: string

--- a/dist/cloudflare/cloudflare-dns-zone-sync.js
+++ b/dist/cloudflare/cloudflare-dns-zone-sync.js
@@ -81,16 +81,8 @@ var _CloudflareDNSZone = class _CloudflareDNSZone extends (_a = CloudflareEntity
     }
   }
   delete() {
-    if (!this.state.id) {
-      cli.output("Zone does not exist, nothing to delete");
-      return;
-    }
-    if (this.state.existing) {
-      cli.output("Zone wasn't created by this entity, skipping delete");
-      return;
-    }
-    this.request("DELETE", `/zones/${this.state.id}`);
-    cli.output("Deleted Cloudflare zone");
+    cli.output("Zone delete is disabled by design; skipping");
+    return;
   }
   checkReadiness() {
     if (!this.state.id) return true;

--- a/dist/cloudflare/cloudflare-dns-zone.yaml
+++ b/dist/cloudflare/cloudflare-dns-zone.yaml
@@ -3,7 +3,7 @@ cloudflare-dns-zone:
   defines: entity
   metadata:
     name: CloudflareDNSZone
-    version-hash: 9ad7d46140b1
+    version-hash: e0206fa9d712
   schema:
     secret_ref:
       type: string

--- a/src/cloudflare/README.md
+++ b/src/cloudflare/README.md
@@ -16,7 +16,7 @@ interface CloudflareDNSZoneDefinition {
   name: string;        // zone name, e.g., example.com
   zone_type?: "full" | "partial"; // default: full
   account_id?: string; // optional account id for creation
-  create_when_missing?: boolean; // skip creation in tests when false
+  // Records are created by default when missing. No opt-out flag.
 }
 ```
 
@@ -35,6 +35,9 @@ Actions (kebab-case):
 - `list-zones`: lists zones in the account
 
 Readiness: waits until zone `status` is `active` (or `pending` during tests).
+
+Deletion policy:
+- Zone deletion is disabled by design (failsafe). The entity's delete() is a no-op.
 
 ### `cloudflare-dns-record`
 

--- a/src/cloudflare/dns-zone.ts
+++ b/src/cloudflare/dns-zone.ts
@@ -51,16 +51,9 @@ export class CloudflareDNSZone extends CloudflareEntity<CloudflareDNSZoneDefinit
   }
 
   override delete(): void {
-    if (!this.state.id) {
-      cli.output("Zone does not exist, nothing to delete");
-      return;
-    }
-    if (this.state.existing) {
-      cli.output("Zone wasn't created by this entity, skipping delete");
-      return;
-    }
-    this.request("DELETE", `/zones/${this.state.id}`);
-    cli.output("Deleted Cloudflare zone");
+    // Failsafe: never delete zones via this entity
+    cli.output("Zone delete is disabled by design; skipping");
+    return;
   }
 
   override checkReadiness(): boolean {

--- a/src/cloudflare/example.yaml
+++ b/src/cloudflare/example.yaml
@@ -1,35 +1,33 @@
 namespace: cloudflare-examples
+nginx:
+  defines: runnable
+  inherits: nginx/node-proxy
 
-example-zone:
-  defines: cloudflare/cloudflare-dns-zone
-  name: example.com
+example-record:
+  defines: cloudflare/cloudflare-dns-record
+  zone_name: thisbetterbe.online
+  name: www
+  record_type: CNAME
+  content: <- connection-domain-name("nginx")
+  ttl: 1
+  proxied: true
   permitted-secrets:
     cloudflare-api-token: true
   services:
     data:
       protocol: custom
-
-example-record:
-  defines: cloudflare/cloudflare-dns-record
-  zone_name: <- connection-target("zone-service") entity-state get-member("name")
-  record_type: A
-  name: www
-  content: 203.0.113.10
-  ttl: 120
-  permitted-secrets:
-    cloudflare-api-token: true
   connections:
-    zone-service:
-      runnable: cloudflare-examples/example-zone
-      service: data
+    nginx:
+      runnable: cloudflare-examples/nginx
+      service: nginx
   depends:
     wait-for:
       runnables:
-        - cloudflare-examples/example-zone
+        - cloudflare-examples/nginx
       timeout: 60
 
 stack:
   defines: process-group
   runnable-list:
-    - cloudflare-examples/example-zone
+    - cloudflare-examples/nginx
     - cloudflare-examples/example-record

--- a/src/cloudflare/test/stack-template.yaml
+++ b/src/cloudflare/test/stack-template.yaml
@@ -2,7 +2,7 @@ namespace: cloudflare-test
 
 zone:
   defines: cloudflare/cloudflare-dns-zone
-  name: example.com
+  name: thisbetterbe.online
   permitted-secrets:
     cloudflare-api-token: true
   services:
@@ -11,15 +11,16 @@ zone:
 
 record:
   defines: cloudflare/cloudflare-dns-record
-  zone_name: <- connection-target("zone-service") entity-state get-member("name")
+  zone_name: <- connection-target("zone") entity-state get-member("name")
   record_type: A
-  name: www
-  content: 203.0.113.10
-  ttl: 120
+  name: www2
+  content: 198.51.100.4
+  ttl: 1 # automatic
+  proxied: true # toggle orange cloud
   permitted-secrets:
     cloudflare-api-token: true
   connections:
-    zone-service:
+    zone:
       runnable: cloudflare-test/zone
       service: data
   depends:


### PR DESCRIPTION
This pull request introduces significant changes to the Cloudflare DNS zone and record management logic, focusing on safer defaults and improved usability. The most important updates include making DNS record creation the default behavior, disabling DNS zone deletion as a failsafe, and updating example/test configurations to reflect these changes and new best practices.

**Cloudflare DNS Zone and Record Management:**

* DNS record creation is now always attempted when missing; the previous opt-out flag (`create_when_missing`) is removed, and records are created by default. [[1]](diffhunk://#diff-4cd7f6b10e883e55ac69f64e7861d0d659e11b059d03ba816427fac2c124976eL19-R19) [[2]](diffhunk://#diff-1721d6879b82f56f7cf650acae91e3481fd39854f27430eebd397024a8460594L55-R80)
* DNS zone deletion is now explicitly disabled for safety—calling `delete()` on a zone entity will output a message and perform no action. [[1]](diffhunk://#diff-4cd7f6b10e883e55ac69f64e7861d0d659e11b059d03ba816427fac2c124976eR39-R41) [[2]](diffhunk://#diff-98fe09dd1fbd64966c258bc8ab90b63ddadf10efe4ba64b5a5355c6d498a0833L54-L64)

**Enhanced Record Lookup Logic:**

* Improved the `findRecord` method to handle multiple candidate names (e.g., `@`, short names, and fully qualified names) when searching for DNS records, increasing robustness.

**Example and Test Configuration Updates:**

* Updated `example.yaml` and `stack-template.yaml` to use new zone/record names, modern connection patterns, and the new record creation defaults. This includes switching to proxied CNAME records and updating dependencies. [[1]](diffhunk://#diff-d6d3b1ea0e32ddf8cee4ac1856d7d0ffd7cce9e80709213b4b2d4cfd064069d2L2-R32) [[2]](diffhunk://#diff-b246c5d190d4254a2b250c12544254a55cd59da3c48bddf6115648f9a5f2aa7aL5-R5) [[3]](diffhunk://#diff-b246c5d190d4254a2b250c12544254a55cd59da3c48bddf6115648f9a5f2aa7aL14-R23)