### PR TITLE
[chore] disable idempotent updates for lambda

### DIFF
--- a/dist/aws-lambda/MANIFEST
+++ b/dist/aws-lambda/MANIFEST
@@ -1,4 +1,4 @@
 REPO aws-lambda
-VERSION_HASH 1c644bdfede8
-LOAD lambda-function.yaml base.yaml common.yaml
-RESOURCES common.js lambda-function-sync.js base.js
+VERSION_HASH 88ac9e832adb
+LOAD base.yaml common.yaml lambda-function.yaml
+RESOURCES base.js common.js lambda-function-sync.js

--- a/dist/aws-lambda/base.js
+++ b/dist/aws-lambda/base.js
@@ -43,6 +43,10 @@ var AWSLambdaEntity = class extends import_base.MonkEntity {
     super(...arguments);
     __publicField(this, "region");
   }
+  // disable skipping updates, as Lambda updates are not fully idempotent
+  isIdempotentUpdateEnabled() {
+    return false;
+  }
   before() {
     this.region = this.definition.region;
   }

--- a/dist/aws-lambda/base.yaml
+++ b/dist/aws-lambda/base.yaml
@@ -3,5 +3,5 @@ namespace: aws-lambda
 base:
   defines: module
   metadata:
-    version-hash: 1c644bdfede8
+    version-hash: 88ac9e832adb
   source: <<< base.js

--- a/dist/aws-lambda/common.yaml
+++ b/dist/aws-lambda/common.yaml
@@ -3,5 +3,5 @@ namespace: aws-lambda
 common:
   defines: module
   metadata:
-    version-hash: 1c644bdfede8
+    version-hash: 88ac9e832adb
   source: <<< common.js

--- a/dist/aws-lambda/lambda-function.yaml
+++ b/dist/aws-lambda/lambda-function.yaml
@@ -3,7 +3,7 @@ lambda-function:
   defines: entity
   metadata:
     name: LambdaFunction
-    version-hash: 1c644bdfede8
+    version-hash: 88ac9e832adb
   schema:
     region:
       type: string

--- a/dist/monkec/MANIFEST
+++ b/dist/monkec/MANIFEST
@@ -1,5 +1,5 @@
 REPO monkec
 VERSION_HASH 1e31de784c59
 VERSION 0.1.0
-LOAD http-client.yaml base.yaml
-RESOURCES base.js http-client.js
+LOAD base.yaml http-client.yaml
+RESOURCES http-client.js base.js

--- a/src/aws-lambda/base.ts
+++ b/src/aws-lambda/base.ts
@@ -123,6 +123,11 @@ export abstract class AWSLambdaEntity<
     D extends AWSLambdaDefinition,
     S extends AWSLambdaState
 > extends MonkEntity<D, S> {
+
+    // disable skipping updates, as Lambda updates are not fully idempotent
+    protected override isIdempotentUpdateEnabled(): boolean {
+        return false;
+    }
     
     protected region!: string;
 

--- a/src/lib/modules/base.d.ts
+++ b/src/lib/modules/base.d.ts
@@ -41,6 +41,7 @@ export abstract class MonkEntity<D extends object, S extends object> {
   delete(): void;
   checkReadiness(): boolean;
   protected handleUnknownAction(action: string, args?: Args): void;
+  protected isIdempotentUpdateEnabled(): boolean;
 }
 
 // Decorator to register a method as an action


### PR DESCRIPTION
This pull request introduces a targeted change to the `AWSLambdaEntity` class to address update idempotency. The main update ensures that Lambda entity updates are always processed, reflecting the non-idempotent nature of Lambda updates.

Key change:

* Disabled idempotent update skipping in `AWSLambdaEntity` by overriding the `isIdempotentUpdateEnabled` method to always return `false`. This ensures that all updates are processed, as Lambda updates are not fully idempotent.