### PR TITLE
[fix] allow startup when token secret missing

### DIFF
--- a/cloudflare/cloudflared.yaml
+++ b/cloudflare/cloudflared.yaml
@@ -13,7 +13,9 @@ cloudflared:
     CLOUDFLARED_TOKEN:
       type: string
       env: CLOUDFLARED_TOKEN
-      value: <- secret($token_secret_ref)
+      # set to empty string if secret is not found to allow startup,
+      # the secret will be set by the entity before this starts
+      value: <- secret($token_secret_ref) if-error("")
     command_options:
       type: string
       value: --no-autoupdate


### PR DESCRIPTION
- Default the token env value to an empty string on secret lookup error so the service can start even if the secret isn't yet available.
- Add an explanatory comment that the secret is expected to be injected by the orchestrator before running.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config change; it only alters how `CLOUDFLARED_TOKEN` is populated when the secret lookup fails, enabling startup without the token present.
> 
> **Overview**
> Updates `cloudflare/cloudflared.yaml` so `CLOUDFLARED_TOKEN` uses `secret($token_secret_ref) if-error("")`, allowing the container to start even when the token secret is missing.
> 
> Adds a brief comment clarifying the secret is expected to be injected by the orchestrator before execution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0dcee3a99036a7f588eb41d5518a33b9a749b8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->