### PR TITLE
fix(gcp): cloud-armor detach uses PATCH + isolated integration test

### DIFF
--- a/dist/gcp/cloud-armor-security-policy-sync.js
+++ b/dist/gcp/cloud-armor-security-policy-sync.js
@@ -458,7 +458,7 @@ var _CloudArmorSecurityPolicy = class _CloudArmorSecurityPolicy extends (_a = Gc
       return;
     }
     cli.output(`Deleting Cloud Armor policy: ${this.definition.name}`);
-    const maxAttempts = 12;
+    const maxAttempts = 24;
     const delayMs = 1e4;
     let detachAttempted = false;
     let lastErr = null;
@@ -513,9 +513,41 @@ var _CloudArmorSecurityPolicy = class _CloudArmorSecurityPolicy extends (_a = Gc
   detachAllReferrers() {
     const policyName = this.definition.name;
     const matches = /* @__PURE__ */ __name((ref) => typeof ref === "string" && ref.length > 0 && (ref === policyName || ref.endsWith(`/securityPolicies/${policyName}`)), "matches");
-    const detach = /* @__PURE__ */ __name((resourceUrl, action2) => {
-      const op = this.post(`${resourceUrl}/${action2}`, { securityPolicy: "" });
-      if (op?.name) this.waitForComputeOperation(op.name);
+    const errStr = /* @__PURE__ */ __name((err) => {
+      if (err instanceof Error) return err.message || String(err);
+      if (err && typeof err === "object") {
+        const m = err.message;
+        if (typeof m === "string" && m.length) return m;
+        try {
+          return JSON.stringify(err);
+        } catch {
+        }
+      }
+      return String(err);
+    }, "errStr");
+    const detach = /* @__PURE__ */ __name((resourceUrl, patchField, label) => {
+      const body = {};
+      body[patchField] = null;
+      try {
+        const op = this.patch(resourceUrl, body);
+        if (op?.name) {
+          try {
+            this.waitForComputeOperation(op.name);
+          } catch (waitErr) {
+            cli.output(
+              `Warning: detach LRO wait failed for ${label}: ${errStr(waitErr)}`
+            );
+            return false;
+          }
+        }
+        cli.output(`Detached ${label}`);
+        return true;
+      } catch (patchErr) {
+        cli.output(
+          `Warning: PATCH (clear ${patchField}) on ${label} threw: ${errStr(patchErr)}`
+        );
+        return false;
+      }
     }, "detach");
     try {
       const list = this.get(
@@ -525,23 +557,15 @@ var _CloudArmorSecurityPolicy = class _CloudArmorSecurityPolicy extends (_a = Gc
         const beUrl = `${COMPUTE_API_URL}/projects/${this.projectId}/global/backendServices/${be.name}`;
         if (matches(be.securityPolicy)) {
           cli.output(`Auto-detaching from backend service ${be.name} (securityPolicy)`);
-          try {
-            detach(beUrl, "setSecurityPolicy");
-          } catch (err) {
-            cli.output(`Warning: detach from ${be.name} failed: ${err instanceof Error ? err.message : String(err)}`);
-          }
+          detach(beUrl, "securityPolicy", `backend service ${be.name}`);
         }
         if (matches(be.edgeSecurityPolicy)) {
           cli.output(`Auto-detaching from backend service ${be.name} (edgeSecurityPolicy)`);
-          try {
-            detach(beUrl, "setEdgeSecurityPolicy");
-          } catch (err) {
-            cli.output(`Warning: edge-detach from ${be.name} failed: ${err instanceof Error ? err.message : String(err)}`);
-          }
+          detach(beUrl, "edgeSecurityPolicy", `backend service ${be.name} (edge)`);
         }
       }
     } catch (err) {
-      cli.output(`Warning: could not list backend services for auto-detach: ${err instanceof Error ? err.message : String(err)}`);
+      cli.output(`Warning: could not list backend services for auto-detach: ${errStr(err)}`);
     }
     try {
       const list = this.get(
@@ -551,15 +575,11 @@ var _CloudArmorSecurityPolicy = class _CloudArmorSecurityPolicy extends (_a = Gc
         if (matches(bb.edgeSecurityPolicy)) {
           cli.output(`Auto-detaching from backend bucket ${bb.name} (edgeSecurityPolicy)`);
           const bbUrl = `${COMPUTE_API_URL}/projects/${this.projectId}/global/backendBuckets/${bb.name}`;
-          try {
-            detach(bbUrl, "setEdgeSecurityPolicy");
-          } catch (err) {
-            cli.output(`Warning: edge-detach from bucket ${bb.name} failed: ${err instanceof Error ? err.message : String(err)}`);
-          }
+          detach(bbUrl, "edgeSecurityPolicy", `backend bucket ${bb.name}`);
         }
       }
     } catch (err) {
-      cli.output(`Warning: could not list backend buckets for auto-detach: ${err instanceof Error ? err.message : String(err)}`);
+      cli.output(`Warning: could not list backend buckets for auto-detach: ${errStr(err)}`);
     }
   }
   checkReadiness() {

--- a/src/gcp/cloud-armor-security-policy.ts
+++ b/src/gcp/cloud-armor-security-policy.ts
@@ -771,7 +771,11 @@ export class CloudArmorSecurityPolicy extends GcpEntity<CloudArmorSecurityPolicy
         // resource the user wants to keep — or when GCP doesn't drop the
         // reference during the referring resource's own delete — we need
         // to detach proactively before the delete will succeed.
-        const maxAttempts = 12;
+        // 24 × 10s = 240s. After auto-detach succeeds GCP can take 60–120s
+        // to drop the reverse-reference on the security policy, which is
+        // why the previous 12-retry window (120s) wasn't enough even
+        // when the PATCH on the referring backend bucket succeeded.
+        const maxAttempts = 24;
         const delayMs = 10000;
         let detachAttempted = false;
         let lastErr: unknown = null;
@@ -839,9 +843,62 @@ export class CloudArmorSecurityPolicy extends GcpEntity<CloudArmorSecurityPolicy
             (ref === policyName ||
              ref.endsWith(`/securityPolicies/${policyName}`));
 
-        const detach = (resourceUrl: string, action: string) => {
-            const op = this.post(`${resourceUrl}/${action}`, { securityPolicy: "" });
-            if (op?.name) this.waitForComputeOperation(op.name);
+        // Robustly stringify thrown values: Goja's native bridge can throw
+        // plain objects with no `.message`, which used to surface in logs
+        // as the literal string "[object Object]" and made it impossible
+        // to tell whether the detach succeeded or silently failed.
+        const errStr = (err: unknown): string => {
+            if (err instanceof Error) return err.message || String(err);
+            if (err && typeof err === "object") {
+                const m = (err as any).message;
+                if (typeof m === "string" && m.length) return m;
+                try { return JSON.stringify(err); } catch { /* fall through */ }
+            }
+            return String(err);
+        };
+
+        // Detach a single resource. Returns true on success, false on
+        // caught failure (with a descriptive cli.output line).
+        //
+        // GCP exposes two ways to clear a security-policy reference and
+        // each has its own gotcha:
+        //   - `POST <resource>/setEdgeSecurityPolicy` (or setSecurityPolicy)
+        //     with `{ "securityPolicy": "" }` — *rejected* with "URL is
+        //     malformed" because the parser requires a valid resource URL.
+        //   - `PATCH <resource>` with `{ "<field>": null }` — accepted, but
+        //     the reverse-reference on the security policy itself doesn't
+        //     fully drop for tens of seconds, so a follow-up policy delete
+        //     can still race.
+        // We use the PATCH path because it's the only one that succeeds at
+        // the API level, and rely on the outer retry loop to wait out the
+        // propagation lag.
+        const detach = (
+            resourceUrl: string,
+            patchField: "securityPolicy" | "edgeSecurityPolicy",
+            label: string,
+        ): boolean => {
+            const body: any = {};
+            body[patchField] = null;
+            try {
+                const op = this.patch(resourceUrl, body);
+                if (op?.name) {
+                    try {
+                        this.waitForComputeOperation(op.name);
+                    } catch (waitErr) {
+                        cli.output(
+                            `Warning: detach LRO wait failed for ${label}: ${errStr(waitErr)}`,
+                        );
+                        return false;
+                    }
+                }
+                cli.output(`Detached ${label}`);
+                return true;
+            } catch (patchErr) {
+                cli.output(
+                    `Warning: PATCH (clear ${patchField}) on ${label} threw: ${errStr(patchErr)}`,
+                );
+                return false;
+            }
         };
 
         // Backend services.
@@ -853,19 +910,15 @@ export class CloudArmorSecurityPolicy extends GcpEntity<CloudArmorSecurityPolicy
                 const beUrl = `${COMPUTE_API_URL}/projects/${this.projectId}/global/backendServices/${be.name}`;
                 if (matches(be.securityPolicy)) {
                     cli.output(`Auto-detaching from backend service ${be.name} (securityPolicy)`);
-                    try { detach(beUrl, "setSecurityPolicy"); } catch (err) {
-                        cli.output(`Warning: detach from ${be.name} failed: ${err instanceof Error ? err.message : String(err)}`);
-                    }
+                    detach(beUrl, "securityPolicy", `backend service ${be.name}`);
                 }
                 if (matches(be.edgeSecurityPolicy)) {
                     cli.output(`Auto-detaching from backend service ${be.name} (edgeSecurityPolicy)`);
-                    try { detach(beUrl, "setEdgeSecurityPolicy"); } catch (err) {
-                        cli.output(`Warning: edge-detach from ${be.name} failed: ${err instanceof Error ? err.message : String(err)}`);
-                    }
+                    detach(beUrl, "edgeSecurityPolicy", `backend service ${be.name} (edge)`);
                 }
             }
         } catch (err) {
-            cli.output(`Warning: could not list backend services for auto-detach: ${err instanceof Error ? err.message : String(err)}`);
+            cli.output(`Warning: could not list backend services for auto-detach: ${errStr(err)}`);
         }
 
         // Backend buckets (edge-only attachment).
@@ -877,13 +930,11 @@ export class CloudArmorSecurityPolicy extends GcpEntity<CloudArmorSecurityPolicy
                 if (matches(bb.edgeSecurityPolicy)) {
                     cli.output(`Auto-detaching from backend bucket ${bb.name} (edgeSecurityPolicy)`);
                     const bbUrl = `${COMPUTE_API_URL}/projects/${this.projectId}/global/backendBuckets/${bb.name}`;
-                    try { detach(bbUrl, "setEdgeSecurityPolicy"); } catch (err) {
-                        cli.output(`Warning: edge-detach from bucket ${bb.name} failed: ${err instanceof Error ? err.message : String(err)}`);
-                    }
+                    detach(bbUrl, "edgeSecurityPolicy", `backend bucket ${bb.name}`);
                 }
             }
         } catch (err) {
-            cli.output(`Warning: could not list backend buckets for auto-detach: ${err instanceof Error ? err.message : String(err)}`);
+            cli.output(`Warning: could not list backend buckets for auto-detach: ${errStr(err)}`);
         }
     }
 

--- a/src/gcp/test/stack-integration-cloud-armor-detach.test.yaml
+++ b/src/gcp/test/stack-integration-cloud-armor-detach.test.yaml
@@ -1,0 +1,115 @@
+# Cloud Armor Auto-Detach Integration Test
+#
+# Verifies that gcp/cloud-armor-security-policy.delete() proactively
+# detaches itself from any referring backend bucket / backend service
+# before retrying the delete API call. Without the fix, the delete fails
+# with 400 "still attached" after 12 retries and the policy is orphaned.
+#
+# Run with:
+#   sudo INPUT_DIR=./src/gcp/ ./monkec.sh test --verbose \
+#     --test-file test/stack-integration-cloud-armor-detach.test.yaml
+
+name: Cloud Armor Auto-Detach Test
+description: Policy delete must auto-detach from a referring backend bucket
+timeout: 900000 # 15 minutes — backend bucket + GCS bucket creates take a moment
+
+secrets:
+  global: {}
+
+setup:
+  - name: Load compiled GCP entity package
+    action: load
+    target: dist/input/gcp/MANIFEST
+    expect:
+      exitCode: 0
+
+  - name: Load auto-detach test template
+    action: load
+    target: input/gcp/test/stack-template-cloud-armor-detach.yaml
+    expect:
+      exitCode: 0
+
+tests:
+  # ==========================================================================
+  # Stand up the dependency chain: API → GCS bucket + Armor policy →
+  # CDN backend bucket attaching the policy.
+  # ==========================================================================
+  - name: Enable required APIs
+    action: run
+    target: gcp-cloud-armor-detach-test/enable-apis
+    args:
+      tag: "local"
+    expect:
+      exitCode: 0
+
+  - name: Wait for APIs ready
+    action: wait
+    target: gcp-cloud-armor-detach-test/enable-apis
+    waitFor:
+      condition: ready
+      timeout: 120000
+
+  - name: Create origin GCS bucket
+    action: run
+    target: gcp-cloud-armor-detach-test/test-bucket
+    args:
+      tag: "local"
+    expect:
+      exitCode: 0
+
+  - name: Wait for bucket ready
+    action: wait
+    target: gcp-cloud-armor-detach-test/test-bucket
+    waitFor:
+      condition: ready
+      timeout: 120000
+
+  - name: Create Cloud Armor edge policy
+    action: run
+    target: gcp-cloud-armor-detach-test/test-armor-policy
+    args:
+      tag: "local"
+    expect:
+      exitCode: 0
+
+  - name: Wait for policy ready
+    action: wait
+    target: gcp-cloud-armor-detach-test/test-armor-policy
+    waitFor:
+      condition: ready
+      timeout: 120000
+
+  - name: Create CDN backend bucket attaching the policy
+    action: run
+    target: gcp-cloud-armor-detach-test/test-backend-bucket
+    args:
+      tag: "local"
+    expect:
+      exitCode: 0
+
+  - name: Wait for backend bucket ready (policy now attached)
+    action: wait
+    target: gcp-cloud-armor-detach-test/test-backend-bucket
+    waitFor:
+      condition: ready
+      timeout: 120000
+
+  # ==========================================================================
+  # The actual test: delete the policy while it's still attached. Without
+  # the auto-detach fix, this fails with 400 after 12 retries. With the
+  # fix, the policy's delete() walks the project, clears the reference on
+  # the backend bucket, and the policy delete succeeds.
+  # ==========================================================================
+  - name: Delete policy while attached — must auto-detach + succeed
+    action: delete
+    target: gcp-cloud-armor-detach-test/test-armor-policy
+    expect:
+      exitCode: 0
+
+# Cleanup intentionally omitted — keep resources around so we can inspect
+# GCP state with gcloud after the test (edgeSecurityPolicy field on the
+# backend bucket should be null/absent if the PATCH detach worked).
+# Manual cleanup:
+#   sudo monk delete --force gcp-cloud-armor-detach-test/test-backend-bucket
+#   sudo monk delete --force gcp-cloud-armor-detach-test/test-bucket
+cleanup: []

--- a/src/gcp/test/stack-template-cloud-armor-detach.yaml
+++ b/src/gcp/test/stack-template-cloud-armor-detach.yaml
@@ -1,0 +1,78 @@
+# Cloud Armor Auto-Detach Test Template
+#
+# Reproduces the teardown scenario from monk-gcp-stack: a Cloud Armor edge
+# policy is referenced by a backend bucket. On group teardown the policy's
+# delete() call gets a 400 "still attached" until the backend's
+# edgeSecurityPolicy reference is cleared. The fix in
+# cloud-armor-security-policy.ts is supposed to detach itself proactively;
+# this template + test exercise that path in isolation, without the
+# 30-minute Cloud SQL provisioning of monk-gcp-stack.
+
+namespace: gcp-cloud-armor-detach-test
+
+# Step 1: Enable APIs the test needs.
+enable-apis:
+  defines: gcp/service-usage
+  apis:
+    - compute.googleapis.com
+    - storage.googleapis.com
+
+# Step 2: GCS bucket — origin for the CDN backend bucket below.
+test-bucket:
+  defines: gcp/cloud-storage
+  name: monk-test-armor-detach-origin
+  location: US
+  storage_class: STANDARD
+  force_ownership: true
+  depends:
+    wait-for:
+      runnables:
+        - gcp-cloud-armor-detach-test/enable-apis
+      timeout: 300
+
+# Step 3: Cloud Armor edge policy. Will be attached to the backend bucket
+# below via that entity's security_policy field. Auto-detach on delete is
+# the behavior under test.
+test-armor-policy:
+  defines: gcp/cloud-armor-security-policy
+  name: monk-test-armor-detach-policy
+  policy_description: Auto-detach test policy
+  policy_type: CLOUD_ARMOR_EDGE
+  force_ownership: true
+  default_action: allow
+  rules:
+    - priority: 1000
+      action: deny(403)
+      src_ip_ranges:
+        - 192.0.2.0/24
+      rule_description: Test-net block (placeholder rule)
+  depends:
+    wait-for:
+      runnables:
+        - gcp-cloud-armor-detach-test/enable-apis
+      timeout: 300
+
+# Step 4: CDN backend bucket attaching the armor policy. This is the
+# referrer that has to be cleared from the policy before the policy can
+# be deleted on GCP. setEdgeSecurityPolicy expects a full self-link, so
+# we wire it via connection-target() + state.self_link rather than a
+# bare policy name.
+test-backend-bucket:
+  defines: gcp/cloud-cdn-backend-bucket
+  name: monk-test-armor-detach-backend
+  bucket_name: monk-test-armor-detach-origin
+  enable_cdn: true
+  cache_mode: CACHE_ALL_STATIC
+  default_ttl: 3600
+  max_ttl: 86400
+  security_policy: <- connection-target("armor") entity-state get-member("self_link")
+  connections:
+    armor:
+      runnable: gcp-cloud-armor-detach-test/test-armor-policy
+      service: default
+  depends:
+    wait-for:
+      runnables:
+        - gcp-cloud-armor-detach-test/test-bucket
+        - gcp-cloud-armor-detach-test/test-armor-policy
+      timeout: 300


### PR DESCRIPTION
## Summary
Follow-up to #197's cloud-armor auto-detach. Three iterations based on isolated integration testing:

- **POST `setEdgeSecurityPolicy` with `{securityPolicy: ""}` doesn't work** — the API rejects it with `400 'securityPolicy': ''. The URL is malformed.` because the value is validated as a URL. Switched to PATCH the backend service / backend bucket directly with `{<field>: null}`.
- **Robust error stringification** — the previous inner try/catch let Goja runtime throws bubble up as the cryptic `[object Object]` string, hiding the real cause. New `detach()` helper returns boolean and stringifies errors via instanceof-Error → message → JSON.stringify → String fallback.
- **24-retry window (240s)** — even when PATCH succeeds and the LRO completes, GCP's reverse-index on the security policy can still report it as attached for ~60–120s.

Adds `src/gcp/test/stack-template-cloud-armor-detach.yaml` + `stack-integration-cloud-armor-detach.test.yaml` so the auto-detach can be exercised in ~3 min instead of redeploying the full monk-gcp-stack (Cloud SQL alone is 10–15 min).

## Caveat
Even with 240s + working PATCH detach, the isolated test still hits the orphan in some runs because GCP's reverse-index lag sometimes outlasts the window. Real-world `monk-gcp-stack` teardowns succeed naturally because the referring backend bucket is deleted in parallel by the same group teardown, which drops the reference faster than a held-alive backend in the test.

## Test plan
- [x] `monkec test --test-file stack-integration-cloud-armor-detach.test.yaml` reproduces the scenario in isolation; logs now clearly show `Auto-detaching → Detached → Policy still attached attempt N/24` instead of `[object Object]`
- [x] PATCH detach call confirmed succeeding (LRO completes, `Detached backend bucket <name>` log line)
- [ ] Full `monk-gcp-stack` teardown — pending; real teardown is the production-like case where the backend is also being deleted, the natural-clear path