### PR TITLE
feat(cloudflare): add r2-bucket entity

### DIFF
--- a/src/cloudflare/README.md
+++ b/src/cloudflare/README.md
@@ -155,6 +155,44 @@ interface CloudflareCustomHostnameFallbackOriginDefinition {
 
 State: `{ origin?, status?, errors?, existing? }`. Actions: `get-info`. Token scope: same as `cloudflare-custom-hostname`.
 
+### `cloudflare-r2-bucket`
+
+Manages an R2 object-storage bucket in a Cloudflare account. Adopts pre-existing buckets by name.
+
+Definition (snake_case):
+
+```ts
+interface CloudflareR2BucketDefinition {
+  secret_ref?: string;       // optional; defaults to cloudflare-api-token
+  account_id: string;        // Cloudflare account ID
+  name: string;              // bucket name (3-63 chars, S3-compatible)
+  location_hint?: "wnam" | "enam" | "weur" | "eeur" | "apac";
+  storage_class?: "Standard" | "InfrequentAccess";
+  allow_destructive_delete?: boolean; // default false; delete() is a no-op unless true
+}
+```
+
+State:
+
+```ts
+interface CloudflareR2BucketState {
+  id?: string;            // bucket name
+  endpoint?: string;      // https://<account_id>.r2.cloudflarestorage.com
+  created_on?: string;
+  location?: string;
+  storage_class?: string;
+  existing?: boolean;
+}
+```
+
+Actions:
+- `get-info`: prints bucket metadata
+- `force-delete`: explicit destructive delete; refuses adopted buckets
+
+Token scope: `Workers R2 Storage:Edit`.
+
+Deletion policy: `delete()` is a no-op unless `allow_destructive_delete: true` is set in the definition. Adopted buckets (`state.existing = true`) are never deleted.
+
 ## Secrets
 
 - Default secret name: `cloudflare-api-token`

--- a/src/cloudflare/example-r2-bucket.yaml
+++ b/src/cloudflare/example-r2-bucket.yaml
@@ -1,0 +1,17 @@
+namespace: cloudflare-r2-example
+
+bucket:
+  defines: cloudflare/cloudflare-r2-bucket
+  account_id: <- secret("cloudflare-account-id")
+  name: my-app-assets
+  location_hint: weur
+  storage_class: Standard
+  # delete() is a no-op by default. Set to true to allow stack-delete to
+  # destroy the bucket (the bucket must be empty for the API to accept it).
+  allow_destructive_delete: false
+  permitted-secrets:
+    cloudflare-api-token: true
+    cloudflare-account-id: true
+  services:
+    data:
+      protocol: custom

--- a/src/cloudflare/r2-bucket.ts
+++ b/src/cloudflare/r2-bucket.ts
@@ -1,0 +1,200 @@
+import { action } from "monkec/base";
+import cli from "cli";
+import { CloudflareEntity, type CloudflareEntityDefinition, type CloudflareEntityState } from "./cloudflare-base.ts";
+
+/**
+ * Definition interface for Cloudflare R2 Bucket entity.
+ * Manages an R2 bucket within a Cloudflare account.
+ * @see https://developers.cloudflare.com/api/operations/r2-create-bucket
+ * @interface CloudflareR2BucketDefinition
+ */
+export interface CloudflareR2BucketDefinition extends CloudflareEntityDefinition {
+  /** @description Cloudflare account ID that owns the bucket */
+  account_id: string;
+  /** @description Bucket name (3-63 chars, S3-compatible). Canonical R2 identifier. */
+  name: string;
+  /** @description Optional region hint at create time */
+  location_hint?: "wnam" | "enam" | "weur" | "eeur" | "apac";
+  /** @description Storage class; defaults to Standard */
+  storage_class?: "Standard" | "InfrequentAccess";
+  /**
+   * @description If true, delete() will destroy the bucket. Defaults to false (no-op delete).
+   * @default false
+   */
+  allow_destructive_delete?: boolean;
+}
+
+/**
+ * State interface for Cloudflare R2 Bucket entity.
+ * @interface CloudflareR2BucketState
+ */
+export interface CloudflareR2BucketState extends CloudflareEntityState {
+  /** @description Bucket name; canonical R2 identifier */
+  id?: string;
+  /** @description S3-compatible endpoint URL for SDK consumers */
+  endpoint?: string;
+  /** @description ISO-8601 timestamp the bucket was created */
+  created_on?: string;
+  /** @description Active location echoed back by Cloudflare */
+  location?: string;
+  /** @description Active storage class */
+  storage_class?: string;
+}
+
+/**
+ * @description Cloudflare R2 Bucket entity.
+ * Detects-then-creates an R2 bucket in the given account. Adopts pre-existing
+ * buckets by name. delete() is a no-op by default; opt in with
+ * `allow_destructive_delete: true` or call the `force-delete` action.
+ *
+ * ## Secrets
+ * - Reads: `secret_ref` (defaults to `cloudflare-api-token`) — needs
+ *   `Workers R2 Storage:Edit` permission.
+ * - Writes: none.
+ *
+ * ## State Fields for Composition
+ * - `state.id` - Bucket name; pass to S3 SDK consumers as the bucket key
+ * - `state.endpoint` - `https://{account_id}.r2.cloudflarestorage.com`
+ *
+ * ## Actions
+ * - `get-info` - Fetch bucket metadata
+ * - `force-delete` - Explicit destructive delete (refuses if state.existing)
+ */
+export class CloudflareR2Bucket extends CloudflareEntity<CloudflareR2BucketDefinition, CloudflareR2BucketState> {
+  static readonly readiness = { period: 5, initialDelay: 1, attempts: 6 };
+
+  override create(): void {
+    const accountId = this.definition.account_id;
+    const name = this.definition.name;
+
+    const existing = this.findBucket(accountId, name);
+    if (existing) {
+      this.state = {
+        id: name,
+        endpoint: this.endpointFor(accountId),
+        created_on: existing.creation_date || existing.created_on,
+        location: existing.location,
+        storage_class: existing.storage_class,
+        existing: true,
+      };
+      cli.output(`📦 Adopted existing R2 bucket ${name}`);
+      return;
+    }
+
+    const payload: Record<string, unknown> = { name };
+    if (this.definition.location_hint) payload.locationHint = this.definition.location_hint;
+    if (this.definition.storage_class) payload.storageClass = this.definition.storage_class;
+
+    const created = this.request<any>("POST", `/accounts/${accountId}/r2/buckets`, payload);
+    const result = created?.result || {};
+
+    this.state = {
+      id: name,
+      endpoint: this.endpointFor(accountId),
+      created_on: result.creation_date || result.created_on,
+      location: result.location,
+      storage_class: result.storage_class || this.definition.storage_class || "Standard",
+      existing: false,
+    };
+    cli.output(`✅ Created R2 bucket ${name}`);
+  }
+
+  override update(): void {
+    if (!this.state.id) {
+      this.create();
+      return;
+    }
+    // Bucket settings (name, location, storage class) are immutable post-create.
+    // Refresh metadata so state stays consistent with provider.
+    try {
+      const accountId = this.definition.account_id;
+      const info = this.request<any>("GET", `/accounts/${accountId}/r2/buckets/${this.state.id}`);
+      const r = info?.result;
+      if (r) {
+        this.state.location = r.location || this.state.location;
+        this.state.storage_class = r.storage_class || this.state.storage_class;
+        this.state.created_on = r.creation_date || r.created_on || this.state.created_on;
+        this.state.endpoint = this.endpointFor(accountId);
+      }
+    } catch {
+      // ignore refresh errors; keep prior state
+    }
+  }
+
+  override delete(): void {
+    if (!this.state.id) return;
+    if (this.state.existing) {
+      cli.output("Bucket existed before this entity; skipping delete");
+      return;
+    }
+    if (!this.definition.allow_destructive_delete) {
+      cli.output(
+        `R2 bucket ${this.state.id} delete is disabled. Set allow_destructive_delete: true ` +
+          `or invoke the force-delete action to remove it.`
+      );
+      return;
+    }
+    this.destroyBucket();
+  }
+
+  override checkReadiness(): boolean {
+    return Boolean(this.state.id);
+  }
+
+  @action("get-info")
+  getInfo(): void {
+    if (!this.state.id) {
+      cli.output("No bucket yet");
+      return;
+    }
+    const accountId = this.definition.account_id;
+    const res = this.request<any>("GET", `/accounts/${accountId}/r2/buckets/${this.state.id}`);
+    cli.output(JSON.stringify(res?.result || {}, null, 2));
+  }
+
+  @action("force-delete")
+  forceDelete(): void {
+    if (!this.state.id) {
+      cli.output("No bucket to delete");
+      return;
+    }
+    if (this.state.existing) {
+      cli.output(
+        `Refusing force-delete: bucket ${this.state.id} pre-existed and was adopted. ` +
+          `Delete it manually if intentional.`
+      );
+      return;
+    }
+    this.destroyBucket();
+  }
+
+  private destroyBucket(): void {
+    const accountId = this.definition.account_id;
+    try {
+      this.request("DELETE", `/accounts/${accountId}/r2/buckets/${this.state.id}`);
+      cli.output(`🗑️ Deleted R2 bucket ${this.state.id}`);
+    } catch (e: any) {
+      const msg = e?.message || String(e);
+      // Tolerate already-gone bucket (force-delete then lifecycle delete, or
+      // out-of-band deletion).
+      if (msg.includes("404") || msg.includes("10006")) {
+        cli.output(`R2 bucket ${this.state.id} already gone`);
+        return;
+      }
+      throw e;
+    }
+  }
+
+  private endpointFor(accountId: string): string {
+    return `https://${accountId}.r2.cloudflarestorage.com`;
+  }
+
+  private findBucket(accountId: string, name: string): any | null {
+    try {
+      const res = this.request<any>("GET", `/accounts/${accountId}/r2/buckets/${name}`);
+      return res?.result || null;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/src/cloudflare/test/env.example
+++ b/src/cloudflare/test/env.example
@@ -1,6 +1,13 @@
 # Cloudflare API token (do not commit real values)
 CLOUDFLARE_API_TOKEN=
 
+# Cloudflare account ID (required for R2 bucket tests)
+CLOUDFLARE_ACCOUNT_ID=
+
+# R2 bucket name used by integration tests; must be globally unique within
+# the account. Override per-CI-run if you want isolation.
+CLOUDFLARE_R2_TEST_BUCKET=monk-r2-test-bucket
+
 # Optional
 MONKEC_VERBOSE=true
 TEST_TIMEOUT=300000

--- a/src/cloudflare/test/stack-integration.test.yaml
+++ b/src/cloudflare/test/stack-integration.test.yaml
@@ -5,6 +5,7 @@ timeout: 300000
 secrets:
   global:
     cloudflare-api-token: "$CLOUDFLARE_API_TOKEN"
+    cloudflare-account-id: "$CLOUDFLARE_ACCOUNT_ID"
 
 setup:
   - name: Load compiled entity (skipped if no Monk permissions)
@@ -99,6 +100,24 @@ tests:
     actionName: get-info
     expect:
       exitCode: 0
+
+  - name: Describe R2 bucket
+    action: describe
+    target: cloudflare-test/bucket
+    expect:
+      exitCode: 0
+      output:
+        - "cloudflare-test/bucket"
+        - "id"
+
+  - name: Get R2 bucket info
+    action: action
+    target: cloudflare-test/bucket
+    actionName: get-info
+    expect:
+      exitCode: 0
+      output:
+        - "monk-r2-test-bucket"
 
 cleanup:
   - name: Delete stack

--- a/src/cloudflare/test/stack-template.yaml
+++ b/src/cloudflare/test/stack-template.yaml
@@ -66,6 +66,20 @@ custom-hostname:
         - cloudflare-test/fallback-origin
       timeout: 60
 
+bucket:
+  defines: cloudflare/cloudflare-r2-bucket
+  account_id: <- secret("cloudflare-account-id")
+  name: monk-r2-test-bucket
+  storage_class: Standard
+  # Tests need cleanup to actually destroy the bucket.
+  allow_destructive_delete: true
+  permitted-secrets:
+    cloudflare-api-token: true
+    cloudflare-account-id: true
+  services:
+    data:
+      protocol: custom
+
 stack:
   defines: group
   members:
@@ -73,3 +87,4 @@ stack:
     - cloudflare-test/record
     - cloudflare-test/fallback-origin
     - cloudflare-test/custom-hostname
+    - cloudflare-test/bucket


### PR DESCRIPTION
## Summary

- Adds `cloudflare/cloudflare-r2-bucket` entity to the existing `src/cloudflare/` package, extending `CloudflareEntity`. Detect-then-create, adopts existing buckets by name, surfaces `state.id` (bucket name) and `state.endpoint` (`https://<account_id>.r2.cloudflarestorage.com`) for S3 SDK consumers.
- Failsafe delete posture: `delete()` is a no-op unless `allow_destructive_delete: true` is set; an explicit `force-delete` action is also exposed. Adopted buckets (`state.existing = true`) are never deleted. Mirrors `cloudflare-tunnel`. The destroy path tolerates a 404 so `monk delete` after `force-delete` doesn't error.
- Test stack and `stack-integration.test.yaml` extended with the new bucket; `env.example` documents the new `CLOUDFLARE_ACCOUNT_ID` requirement (sourced via `<- secret("cloudflare-account-id")`, matching the pattern in `example-tunnel.yaml`).
- First entity from the BlocCarbon required-entities backlog (Gap 1). Jurisdiction header support and `set-cors` action deferred to follow-ups.

## Test plan

- [x] Compile clean: `INPUT_DIR=./src/cloudflare/ OUTPUT_DIR=./dist/cloudflare/ ./monkec.sh compile` produces `cloudflare/cloudflare-r2-bucket`
- [x] Manual lifecycle against live monk daemon: create → readiness → `get-info` → update (idempotent) → `force-delete` → lifecycle delete (404-tolerant)
- [x] Automated suite: `deno task test input/cloudflare --verbose` (host-runnable from sibling monkec checkout) — 10/10 steps pass, including the two new R2 cases
- [ ] Reviewer: confirm the failsafe-delete posture is the right default for R2 (matches `cloudflare-tunnel`)