### PR TITLE
feat(cloudflare): workers-script + workers-route entities, wrangler-deploy runnable

### DIFF
--- a/cloudflare/MANIFEST
+++ b/cloudflare/MANIFEST
@@ -1,2 +1,3 @@
 REPO monk-cloudflare
-LOAD cloudflared.yaml
+LOAD cloudflared.yaml wrangler-deploy.yaml
+

--- a/cloudflare/wrangler-deploy.yaml
+++ b/cloudflare/wrangler-deploy.yaml
@@ -1,0 +1,155 @@
+namespace: cloudflare
+
+# Cloudflare Workers deployment runnable.
+# Mirrors vercel/deploy + netlify/deploy: blob-mounted source, generic
+# node container, vendor CLI (wrangler) drives the upload.
+#
+# Inheritors mount their built Worker bundle from a Monk blob and pass
+# bindings + secrets via variables. init.sh generates wrangler.toml on
+# the fly from the JSON inputs, then runs `wrangler deploy`.
+#
+# Code lives outside Monk (CI builds the bundle, puts it in a blob);
+# Monk owns the upload, bindings contract, routes, and secret rotation.
+wrangler-deploy:
+  defines: runnable
+  permitted-secrets:
+    cloudflare-api-token: true
+  containers:
+    deploy:
+      image: node:20-alpine
+      restart: no
+      bash: /tmp/init.sh
+      paths:
+        - <- `blobs://${source-path}:/home/node/app`
+  files:
+    init:
+      container: deploy
+      path: /tmp/init.sh
+      mode: 0755
+      contents: |
+        #!/bin/sh
+        set -eu
+
+        echo "🚀 Cloudflare Workers deploy"
+        echo "  Script:    $WORKER_NAME"
+        echo "  Account:   $CLOUDFLARE_ACCOUNT_ID"
+        echo "  Directory: $DEPLOY_DIR"
+
+        cd "$DEPLOY_DIR"
+
+        apk add --no-cache jq >/dev/null 2>&1 || true
+
+        # Optional pre-deploy step (template-substituted into the script).
+        {{ v "pre-deploy" }}
+
+        # Build wrangler.toml from the JSON inputs. We always write a
+        # fresh file — any committed wrangler.toml in the bundle is
+        # overwritten so the entity definition is the source of truth.
+        TOML=wrangler.toml
+        {
+          printf 'name = "%s"\n' "$WORKER_NAME"
+          printf 'main = "%s"\n' "$WORKER_MAIN"
+          [ -n "$COMPATIBILITY_DATE" ] && printf 'compatibility_date = "%s"\n' "$COMPATIBILITY_DATE"
+          if [ -n "$COMPATIBILITY_FLAGS" ]; then
+            FLAGS=$(echo "$COMPATIBILITY_FLAGS" | jq -R 'split(" ") | map("\"\(.)\"") | join(",")')
+            printf 'compatibility_flags = [%s]\n' "$FLAGS"
+          fi
+
+          # Routes in wrangler.toml let wrangler publish without a
+          # registered workers.dev subdomain. If routes-json is empty,
+          # wrangler falls back to workers.dev (account must have a
+          # subdomain registered).
+          if [ "$ROUTES_JSON" != "[]" ] && [ -n "$ROUTES_JSON" ]; then
+            echo 'workers_dev = false'
+            echo "$ROUTES_JSON" | jq -r '.[] | "[[routes]]\npattern = \"\(.pattern)\"\nzone_name = \"\(.zone_name)\""'
+          fi
+
+          if [ "$BINDINGS_JSON" != "{}" ] && [ -n "$BINDINGS_JSON" ]; then
+            # Plain vars
+            VARS=$(echo "$BINDINGS_JSON" | jq -r '.vars // {} | to_entries[] | "\(.key) = \"\(.value)\""')
+            if [ -n "$VARS" ]; then
+              echo '[vars]'
+              echo "$VARS"
+            fi
+            # R2 buckets
+            echo "$BINDINGS_JSON" | jq -r '.r2 // [] | .[] | "[[r2_buckets]]\nbinding = \"\(.name)\"\nbucket_name = \"\(.bucket_name)\""'
+            # KV namespaces
+            echo "$BINDINGS_JSON" | jq -r '.kv // [] | .[] | "[[kv_namespaces]]\nbinding = \"\(.name)\"\nid = \"\(.namespace_id)\""'
+            # Queue producers
+            echo "$BINDINGS_JSON" | jq -r '.queues // [] | .[] | "[[queues.producers]]\nbinding = \"\(.name)\"\nqueue = \"\(.queue_name)\""'
+            # Durable Object bindings
+            echo "$BINDINGS_JSON" | jq -r '.durable_objects // [] | .[] | "[[durable_objects.bindings]]\nname = \"\(.name)\"\nclass_name = \"\(.class_name)\"" + (if .script_name then "\nscript_name = \"" + .script_name + "\"" else "" end)'
+          fi
+        } > "$TOML"
+
+        echo "── wrangler.toml ─────────────────────────────────────"
+        cat "$TOML"
+        echo "──────────────────────────────────────────────────────"
+
+        # Auth via env: wrangler reads CLOUDFLARE_API_TOKEN + CLOUDFLARE_ACCOUNT_ID
+        npx --yes "wrangler@$WRANGLER_VERSION" deploy
+
+        # Push secrets after deploy (wrangler secret put requires the
+        # script to exist). $SECRETS_JSON is a flat object {NAME: VALUE},
+        # fully resolved at template time via <- secret(...).
+        if [ "$SECRETS_JSON" != "{}" ] && [ -n "$SECRETS_JSON" ]; then
+          echo "🔐 Pushing secrets"
+          echo "$SECRETS_JSON" | jq -r 'to_entries[] | "\(.key)\t\(.value)"' | while IFS=$(printf '\t') read -r name value; do
+            printf '%s' "$value" | npx --yes "wrangler@$WRANGLER_VERSION" secret put "$name" --name "$WORKER_NAME"
+          done
+        fi
+
+        echo "✅ Worker $WORKER_NAME deployed"
+  variables:
+    source-path:
+      type: string
+      value: worker
+    script-name:
+      env: WORKER_NAME
+      type: string
+    worker-main:
+      env: WORKER_MAIN
+      type: string
+      value: src/index.js
+    account-id:
+      env: CLOUDFLARE_ACCOUNT_ID
+      type: string
+      value: <- secret("cloudflare-account-id")
+    api-token:
+      env: CLOUDFLARE_API_TOKEN
+      type: string
+      value: <- secret("cloudflare-api-token")
+    deploy-dir:
+      env: DEPLOY_DIR
+      type: string
+      value: /home/node/app
+    compatibility-date:
+      env: COMPATIBILITY_DATE
+      type: string
+      value: ""
+    compatibility-flags:
+      env: COMPATIBILITY_FLAGS
+      type: string
+      value: ""
+    routes-json:
+      env: ROUTES_JSON
+      type: string
+      value: "[]"
+    bindings-json:
+      env: BINDINGS_JSON
+      type: string
+      value: "{}"
+    secrets-json:
+      env: SECRETS_JSON
+      type: string
+      value: "{}"
+    wrangler-version:
+      env: WRANGLER_VERSION
+      type: string
+      value: "^3"
+    pre-deploy:
+      type: string
+      value: |
+        # Default pre-deploy is a no-op; inheritors override to add
+        # npm install / bun install / build steps.
+        :

--- a/src/cloudflare/README.md
+++ b/src/cloudflare/README.md
@@ -193,6 +193,87 @@ Token scope: `Workers R2 Storage:Edit`.
 
 Deletion policy: `delete()` is a no-op unless `allow_destructive_delete: true` is set in the definition. Adopted buckets (`state.existing = true`) are never deleted.
 
+### `cloudflare-workers-script`
+
+Reserves a Worker name as a Cloudflare resource. Detects-then-stubs: if a script with the given name already exists in the account, it is adopted; if not, a tiny stub is uploaded so the resource exists and other entities/runnables can wire to it. Real code is then deployed via `cloudflare/wrangler-deploy`, which overwrites the stub.
+
+Definition (snake_case):
+
+```ts
+interface CloudflareWorkersScriptDefinition {
+  secret_ref?: string;              // optional; defaults to cloudflare-api-token
+  account_id: string;
+  name: string;                     // canonical Worker script name
+  compatibility_date?: string;      // for the initial stub; wrangler-deploy sets the real value
+  allow_destructive_delete?: boolean; // default false; delete() is a no-op unless true
+}
+```
+
+State: `{ id?: string; created_on?: string; modified_on?: string; etag?: string; existing?: boolean }`.
+
+Actions: `get-info`, `force-delete`.
+
+Token scope: `Workers Scripts: Edit` on the account. Adopted scripts (`state.existing = true`) are skipped by `delete()` and `force-delete`. Adopted scripts (uploaded by something else, e.g. wrangler in CI) are the common case in production — Monk owns the *resource*, wrangler owns the *content*.
+
+Why a stub? CF's script-upload API doesn't have an "empty Worker" endpoint — every PUT needs a body. The stub is a service-worker that returns 503 with the message `monk: pending wrangler-deploy`, intended to be overwritten on the first `wrangler deploy`.
+
+### `cloudflare-workers-route`
+
+Maps a URL pattern on a zone to a Worker script. Adopts existing routes by `(pattern, script_name)`.
+
+Definition (snake_case):
+
+```ts
+interface CloudflareWorkersRouteDefinition {
+  secret_ref?: string;       // optional; defaults to cloudflare-api-token
+  zone_id: string;           // Cloudflare zone ID
+  route_pattern: string;     // e.g., "api.example.com/*" — quote in YAML
+  script_name: string;       // Worker script name to bind
+}
+```
+
+State: `{ id?: string; existing?: boolean }`.
+
+Actions: `get-info`.
+
+Token scope: `Workers Routes: Edit` on the zone. Adopted routes (`state.existing = true`) are skipped by `delete()`; fresh routes are destroyed.
+
+Note: the field is named `route_pattern`, not `pattern`, because `pattern` is a reserved JSON Schema keyword.
+
+## Runnables
+
+### `cloudflare/wrangler-deploy`
+
+Companion runnable that uploads a Worker bundle via the `wrangler` CLI. Mirrors the `vercel/deploy` / `netlify/deploy` pattern: the operator packs source into a Monk blob, the runnable mounts it, generates `wrangler.toml` from JSON-encoded inputs, runs `wrangler deploy`, then pushes secrets.
+
+Inherit it from a runnable in your stack and pass variables:
+
+```yaml
+deploy:
+  defines: runnable
+  inherits: cloudflare/wrangler-deploy
+  permitted-secrets:
+    cloudflare-api-token: true
+    cloudflare-account-id: true
+  variables:
+    source-path:        { type: string, value: my-worker-blob }
+    script-name:        { type: string, value: my-worker }
+    worker-main:        { type: string, value: src/index.js }
+    compatibility-date: { type: string, value: "2025-04-01" }
+    routes-json:        { type: string, value: '[{"pattern":"example.com/api/*","zone_name":"example.com"}]' }
+    bindings-json:      { type: string, value: '{"r2":[{"name":"ASSETS","bucket_name":"my-bucket"}],"vars":{"APP_ENV":"production"}}' }
+    secrets-json:       { type: string, value: '{}' }     # JSON map of NAME→VALUE, fully resolved at template time
+    pre-deploy:         { type: string, value: "npm ci && npm run build" }
+```
+
+`routes-json`, `bindings-json`, `secrets-json` are JSON strings (composable via Monk template expressions). When `routes-json` is non-empty the runnable sets `workers_dev = false` and adds `[[routes]]` blocks to `wrangler.toml`, so an account without a registered workers.dev subdomain can still deploy.
+
+Combine with the `cloudflare-workers-route` entity when you want routes managed declaratively outside the wrangler config (e.g. dynamic per-tenant routes added after deploy).
+
+Pack a blob: `monk blobs store --name my-worker-blob /path/to/bundled-worker`.
+
+Variable names are kebab-case (`source-path`, `script-name`, `pre-deploy`, etc.) per the runnable convention. Env-mapped variables map to `SCREAMING_SNAKE` env vars inside the container (`source-path` → `SOURCE_PATH` if it had an `env:` mapping; here it's only used by Monk's path interpolation).
+
 ## Secrets
 
 - Default secret name: `cloudflare-api-token`

--- a/src/cloudflare/README.md
+++ b/src/cloudflare/README.md
@@ -240,6 +240,68 @@ Token scope: `Workers Routes: Edit` on the zone. Adopted routes (`state.existing
 
 Note: the field is named `route_pattern`, not `pattern`, because `pattern` is a reserved JSON Schema keyword.
 
+### `cloudflare-queue`
+
+Manages an account-scoped Cloudflare Queue. Adopts existing queues by name. Delete is disabled by default (queues may hold messages); enable with `allow_destructive_delete: true` or invoke `force-delete`.
+
+Definition (snake_case):
+
+```ts
+interface CloudflareQueueDefinition {
+  secret_ref?: string;
+  account_id: string;
+  name: string;
+  settings?: {
+    delivery_delay?: number;          // seconds, 0–42300
+    delivery_paused?: boolean;
+    message_retention_period?: number; // seconds, 60–1209600 (14 days)
+  };
+  allow_destructive_delete?: boolean;
+}
+```
+
+State exposes `id` (queue id) and `name`. Token needs `Workers Queues: Edit`.
+
+Actions: `get-info`, `send-message` (args `message`), `pull-messages` (args `batch_size`, `visibility_timeout_ms`), `drain-messages` (pull-and-ack until empty), `force-delete`.
+
+### `cloudflare-queue-consumer`
+
+Binds a Worker script as the consumer for a queue. Adopts existing consumers matched on `(queue_id, script_name)`.
+
+```ts
+interface CloudflareQueueConsumerDefinition {
+  secret_ref?: string;
+  account_id: string;
+  queue_id: string;
+  script_name: string;
+  settings?: {
+    batch_size?: number;
+    max_concurrency?: number;
+    max_retries?: number;
+    max_wait_time_ms?: number;
+    retry_delay?: number;
+  };
+  dead_letter_queue?: string;
+}
+```
+
+Actions: `get-info`, `list-consumers`. The Worker script must declare a `queue` handler to actually process messages — the script entity's stub only registers `fetch`, so consumer delivery is not exercised end-to-end by this entity alone.
+
+### `cloudflare-workers-cron-trigger`
+
+Owns the full cron list for a Worker script. Applying this entity is a full-replace of `PUT /schedules` — don't mix with crons managed by `wrangler.toml`.
+
+```ts
+interface CloudflareWorkersCronTriggerDefinition {
+  secret_ref?: string;
+  account_id: string;
+  script_name: string;
+  crons: string[]; // standard UTC 5-field cron expressions
+}
+```
+
+Actions: `get-schedules`, `apply` (re-PUT after a script swap).
+
 ## Runnables
 
 ### `cloudflare/wrangler-deploy`

--- a/src/cloudflare/example-queue.yaml
+++ b/src/cloudflare/example-queue.yaml
@@ -1,0 +1,104 @@
+namespace: cloudflare-queue-example
+
+# Reserves the Worker name. Code is uploaded later via wrangler-deploy.
+# The worker script you ship must export a `queue` handler to actually
+# process messages.
+worker:
+  defines: cloudflare/cloudflare-workers-script
+  account_id: <- secret("cloudflare-account-id")
+  name: my-app-queue-worker
+  compatibility_date: "2025-04-01"
+  permitted-secrets:
+    cloudflare-api-token: true
+    cloudflare-account-id: true
+  services:
+    data:
+      protocol: custom
+
+main-queue:
+  defines: cloudflare/cloudflare-queue
+  account_id: <- secret("cloudflare-account-id")
+  name: my-app-main-queue
+  settings:
+    message_retention_period: 86400
+  permitted-secrets:
+    cloudflare-api-token: true
+    cloudflare-account-id: true
+  services:
+    data:
+      protocol: custom
+
+dlq:
+  defines: cloudflare/cloudflare-queue
+  account_id: <- secret("cloudflare-account-id")
+  name: my-app-main-queue-dlq
+  permitted-secrets:
+    cloudflare-api-token: true
+    cloudflare-account-id: true
+  services:
+    data:
+      protocol: custom
+
+# Bind the worker as the consumer for main-queue, with dlq as the
+# dead-letter target. Use connection-target so it works wherever the
+# queue id lives.
+consumer:
+  defines: cloudflare/cloudflare-queue-consumer
+  account_id: <- secret("cloudflare-account-id")
+  queue_id: <- connection-target("queue") entity-state get-member("id")
+  script_name: <- connection-target("worker") entity-state get-member("id")
+  dead_letter_queue: my-app-main-queue-dlq
+  settings:
+    batch_size: 10
+    max_concurrency: 2
+    max_retries: 3
+    max_wait_time_ms: 5000
+    retry_delay: 5
+  permitted-secrets:
+    cloudflare-api-token: true
+    cloudflare-account-id: true
+  connections:
+    queue:
+      runnable: cloudflare-queue-example/main-queue
+      service: data
+    worker:
+      runnable: cloudflare-queue-example/worker
+      service: data
+  depends:
+    wait-for:
+      runnables:
+        - cloudflare-queue-example/main-queue
+        - cloudflare-queue-example/worker
+        - cloudflare-queue-example/dlq
+      timeout: 60
+
+# Nightly + hourly schedules; this entity OWNS the full cron list for
+# the worker (full-replace PUT /schedules).
+crons:
+  defines: cloudflare/cloudflare-workers-cron-trigger
+  account_id: <- secret("cloudflare-account-id")
+  script_name: <- connection-target("worker") entity-state get-member("id")
+  crons:
+    - "0 3 * * *"   # nightly factor sync
+    - "*/30 * * * *" # half-hourly reconciliation
+  permitted-secrets:
+    cloudflare-api-token: true
+    cloudflare-account-id: true
+  connections:
+    worker:
+      runnable: cloudflare-queue-example/worker
+      service: data
+  depends:
+    wait-for:
+      runnables:
+        - cloudflare-queue-example/worker
+      timeout: 60
+
+stack:
+  defines: group
+  members:
+    - cloudflare-queue-example/worker
+    - cloudflare-queue-example/main-queue
+    - cloudflare-queue-example/dlq
+    - cloudflare-queue-example/consumer
+    - cloudflare-queue-example/crons

--- a/src/cloudflare/example-workers.yaml
+++ b/src/cloudflare/example-workers.yaml
@@ -1,0 +1,99 @@
+namespace: cloudflare-workers-example
+
+# Example showing the script entity + deploy runnable + route entity
+# working together. Composes with an R2 bucket via state lookup.
+#
+# Prerequisite: pack your built Worker bundle into a Monk blob first:
+#   monk blobs store --name worker /path/to/bundled-worker
+# (the directory should contain src/index.js or whatever worker-main points at).
+
+my-bucket:
+  defines: cloudflare/cloudflare-r2-bucket
+  account_id: <- secret("cloudflare-account-id")
+  name: my-app-assets
+  permitted-secrets:
+    cloudflare-api-token: true
+    cloudflare-account-id: true
+  services:
+    data:
+      protocol: custom
+
+# The script entity reserves the Worker as a Cloudflare resource. On
+# first apply it uploads a tiny stub so the resource exists and
+# dependents (the deploy runnable, the route entity) can wire to it.
+worker:
+  defines: cloudflare/cloudflare-workers-script
+  account_id: <- secret("cloudflare-account-id")
+  name: my-app-worker
+  compatibility_date: "2025-04-01"
+  permitted-secrets:
+    cloudflare-api-token: true
+    cloudflare-account-id: true
+  services:
+    data:
+      protocol: custom
+
+# The deploy runnable. Uploads the real Worker bundle via wrangler,
+# overwriting the stub the script entity placed.
+deploy:
+  defines: runnable
+  inherits: cloudflare/wrangler-deploy
+  permitted-secrets:
+    cloudflare-api-token: true
+    cloudflare-account-id: true
+    my-app-database-url: true
+  variables:
+    source-path: worker
+    script-name: <- connection-target("worker") entity-state get-member("id")
+    worker-main: src/index.js
+    compatibility-date: "2025-04-01"
+    compatibility-flags: nodejs_compat
+    routes-json: '[{"pattern":"api.example.com/*","zone_name":"example.com"}]'
+    bindings-json: <- `{"r2":[{"name":"ASSETS","bucket_name":"${connection-target("bucket") entity-state get-member("id")}"}],"vars":{"APP_ENV":"production"}}`
+    secrets-json: <- `{"DATABASE_URL":"${secret("my-app-database-url")}"}`
+    pre-deploy: |
+      echo "📦 Installing deps and bundling..."
+      npm ci
+      npm run build
+  connections:
+    worker:
+      runnable: cloudflare-workers-example/worker
+      service: data
+    bucket:
+      runnable: cloudflare-workers-example/my-bucket
+      service: data
+  depends:
+    wait-for:
+      runnables:
+        - cloudflare-workers-example/worker
+        - cloudflare-workers-example/my-bucket
+      timeout: 60
+
+# Route bindings: zone-scoped, managed by the workers-route entity. Use
+# this when you want routes declared declaratively on top of the
+# deployed Worker (e.g. per-tenant dynamic routes added after deploy).
+extra-route:
+  defines: cloudflare/cloudflare-workers-route
+  zone_id: <- secret("cloudflare-zone-id")
+  route_pattern: "admin.example.com/*"
+  script_name: <- connection-target("worker") entity-state get-member("id")
+  permitted-secrets:
+    cloudflare-api-token: true
+    cloudflare-zone-id: true
+  connections:
+    worker:
+      runnable: cloudflare-workers-example/worker
+      service: data
+  depends:
+    wait-for:
+      runnables:
+        - cloudflare-workers-example/deploy
+      timeout: 600
+
+stack:
+  defines: group
+  members:
+    - cloudflare-workers-example/my-bucket
+    - cloudflare-workers-example/worker
+    - cloudflare-workers-example/deploy
+    - cloudflare-workers-example/extra-route

--- a/src/cloudflare/queue-consumer.ts
+++ b/src/cloudflare/queue-consumer.ts
@@ -1,0 +1,244 @@
+import { action } from "monkec/base";
+import cli from "cli";
+import {
+  CloudflareEntity,
+  type CloudflareEntityDefinition,
+  type CloudflareEntityState,
+} from "./cloudflare-base.ts";
+
+/**
+ * Definition interface for a Cloudflare Queue Worker consumer.
+ * Binds a Worker script as the consumer for a queue. One worker consumer
+ * per queue (CF API constraint).
+ * @see https://developers.cloudflare.com/api/resources/queues/subresources/consumers/methods/create/
+ * @interface CloudflareQueueConsumerDefinition
+ */
+export interface CloudflareQueueConsumerDefinition extends CloudflareEntityDefinition {
+  /** @description Cloudflare account ID */
+  account_id: string;
+  /** @description Cloudflare queue ID (typically wired via connection-target) */
+  queue_id: string;
+  /**
+   * @description Consumer type. "worker" binds a script; "http_pull" enables
+   * the REST pull API on the queue. Default: "worker".
+   */
+  consumer_type?: "worker" | "http_pull";
+  /**
+   * @description Worker script name that will receive messages. Required
+   * for `consumer_type: "worker"`; ignored for `"http_pull"`.
+   */
+  script_name?: string;
+  /** @description Optional consumer delivery settings */
+  settings?: {
+    /** @description Max messages per batch */
+    batch_size?: number;
+    /** @description Max concurrent invocations */
+    max_concurrency?: number;
+    /** @description Retries before dead-letter / drop */
+    max_retries?: number;
+    /** @description Max wait (ms) before delivering a partial batch */
+    max_wait_time_ms?: number;
+    /** @description Delay (s) before retrying a failed message */
+    retry_delay?: number;
+  };
+  /** @description Optional dead-letter queue name */
+  dead_letter_queue?: string;
+}
+
+/**
+ * State interface for a Cloudflare Queue consumer.
+ * @interface CloudflareQueueConsumerState
+ */
+export interface CloudflareQueueConsumerState extends CloudflareEntityState {
+  /** @description Cloudflare consumer ID */
+  id?: string;
+  /** @description Queue ID this consumer is bound to */
+  queue_id?: string;
+  /** @description Worker script name (mirror for diagnostics) */
+  script_name?: string;
+}
+
+/**
+ * @description Cloudflare Queue Consumer entity.
+ * Binds a Worker script as the consumer for a queue. Adopts existing
+ * consumers by matching `(queue_id, script_name)`. Delete removes the
+ * binding (the script and queue are untouched). Adopted consumers
+ * (`state.existing = true`) are skipped on delete.
+ *
+ * ## Secrets
+ * - Reads: `secret_ref` (defaults to `cloudflare-api-token`) — needs
+ *   `Workers Queues: Edit` scope on the account.
+ *
+ * ## Actions
+ * - `get-info` — print the consumer record
+ * - `list-consumers` — list all consumers on the bound queue (debugging)
+ */
+export class CloudflareQueueConsumer extends CloudflareEntity<
+  CloudflareQueueConsumerDefinition,
+  CloudflareQueueConsumerState
+> {
+  static readonly readiness = { period: 5, initialDelay: 1, attempts: 6 };
+
+  override create(): void {
+    const accountId = this.definition.account_id;
+    const queueId = this.definition.queue_id;
+    const type = this.definition.consumer_type || "worker";
+    const scriptName = this.definition.script_name;
+
+    if (type === "worker" && !scriptName) {
+      throw new Error("script_name is required when consumer_type is 'worker'");
+    }
+
+    const existing = this.findConsumer(accountId, queueId, type, scriptName);
+    if (existing?.consumer_id) {
+      this.state = {
+        id: existing.consumer_id,
+        queue_id: queueId,
+        script_name: scriptName,
+        existing: true,
+      };
+      cli.output(
+        `🔗 Adopted existing queue consumer ${existing.consumer_id} (${type}${scriptName ? ` → ${scriptName}` : ""})`
+      );
+      return;
+    }
+
+    const body: any = { type };
+    if (type === "worker") body.script_name = scriptName;
+    if (this.definition.settings) body.settings = this.definition.settings;
+    if (this.definition.dead_letter_queue) {
+      body.dead_letter_queue = this.definition.dead_letter_queue;
+    }
+
+    const created = this.request<any>(
+      "POST",
+      `/accounts/${accountId}/queues/${queueId}/consumers`,
+      body
+    );
+    const result = created?.result || {};
+    this.state = {
+      id: result.consumer_id || result.id,
+      queue_id: queueId,
+      script_name: scriptName,
+      existing: false,
+    };
+    cli.output(
+      `✅ Bound queue consumer (${type}): ${scriptName || "http_pull"} → queue ${queueId} (${this.state.id})`
+    );
+  }
+
+  override update(): void {
+    if (!this.state.id) {
+      this.create();
+      return;
+    }
+    const accountId = this.definition.account_id;
+    const queueId = this.definition.queue_id;
+
+    const type = this.definition.consumer_type || "worker";
+    const body: any = { type };
+    if (type === "worker") body.script_name = this.definition.script_name;
+    if (this.definition.settings) body.settings = this.definition.settings;
+    if (this.definition.dead_letter_queue) {
+      body.dead_letter_queue = this.definition.dead_letter_queue;
+    }
+
+    try {
+      this.request<any>(
+        "PATCH",
+        `/accounts/${accountId}/queues/${queueId}/consumers/${this.state.id}`,
+        body
+      );
+    } catch (e: any) {
+      cli.output(`Consumer PATCH failed: ${e?.message || e}`);
+    }
+  }
+
+  override delete(): void {
+    if (!this.state.id) return;
+    if (this.state.existing) {
+      cli.output("Consumer existed before this entity; skipping delete");
+      return;
+    }
+    const accountId = this.definition.account_id;
+    const queueId = this.definition.queue_id;
+    try {
+      this.request(
+        "DELETE",
+        `/accounts/${accountId}/queues/${queueId}/consumers/${this.state.id}`
+      );
+      cli.output(`🗑️ Deleted queue consumer ${this.state.id}`);
+    } catch (e: any) {
+      const msg = e?.message || String(e);
+      if (msg.includes("404")) {
+        cli.output(`Consumer ${this.state.id} already gone`);
+        return;
+      }
+      throw e;
+    }
+  }
+
+  override checkReadiness(): boolean {
+    return Boolean(this.state.id);
+  }
+
+  @action("get-info")
+  getInfo(): void {
+    if (!this.state.id) {
+      cli.output("No consumer yet");
+      return;
+    }
+    const accountId = this.definition.account_id;
+    const queueId = this.definition.queue_id;
+    const res = this.request<any>(
+      "GET",
+      `/accounts/${accountId}/queues/${queueId}/consumers`
+    );
+    const consumers: any[] = res?.result || [];
+    const match = consumers.find(
+      (c) => (c.consumer_id || c.id) === this.state.id
+    );
+    cli.output(JSON.stringify(match || { consumers }, null, 2));
+  }
+
+  @action("list-consumers")
+  listConsumers(): void {
+    const accountId = this.definition.account_id;
+    const queueId = this.definition.queue_id;
+    const res = this.request<any>(
+      "GET",
+      `/accounts/${accountId}/queues/${queueId}/consumers`
+    );
+    cli.output(JSON.stringify(res?.result || [], null, 2));
+  }
+
+  private findConsumer(
+    accountId: string,
+    queueId: string,
+    type: "worker" | "http_pull",
+    scriptName?: string
+  ): any | null {
+    try {
+      const res = this.request<any>(
+        "GET",
+        `/accounts/${accountId}/queues/${queueId}/consumers`
+      );
+      const consumers: any[] = res?.result || [];
+      for (const c of consumers) {
+        const cid = c?.consumer_id || c?.id;
+        if (!cid) continue;
+        const cType = c?.type || (c?.script_name ? "worker" : "http_pull");
+        if (type === "worker") {
+          if (cType === "worker" && c?.script_name === scriptName) {
+            return { ...c, consumer_id: cid };
+          }
+        } else {
+          if (cType === "http_pull") return { ...c, consumer_id: cid };
+        }
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/src/cloudflare/queue.ts
+++ b/src/cloudflare/queue.ts
@@ -1,0 +1,304 @@
+import { action } from "monkec/base";
+import cli from "cli";
+import {
+  CloudflareEntity,
+  type CloudflareEntityDefinition,
+  type CloudflareEntityState,
+} from "./cloudflare-base.ts";
+
+/**
+ * Definition interface for a Cloudflare Queue.
+ * @see https://developers.cloudflare.com/api/resources/queues/methods/create/
+ * @interface CloudflareQueueDefinition
+ */
+export interface CloudflareQueueDefinition extends CloudflareEntityDefinition {
+  /** @description Cloudflare account ID that owns the queue */
+  account_id: string;
+  /** @description Queue name; canonical identifier within the account */
+  name: string;
+  /** @description Optional queue-level settings */
+  settings?: {
+    /** @description Seconds to delay before delivery; 0–42300 */
+    delivery_delay?: number;
+    /** @description Pause/resume delivery to consumers */
+    delivery_paused?: boolean;
+    /** @description Retention seconds; 60–1209600 (14 days max) */
+    message_retention_period?: number;
+  };
+  /**
+   * @description If true, delete() destroys the queue. Default false (no-op).
+   * @default false
+   */
+  allow_destructive_delete?: boolean;
+}
+
+/**
+ * State interface for a Cloudflare Queue.
+ * @interface CloudflareQueueState
+ */
+export interface CloudflareQueueState extends CloudflareEntityState {
+  /** @description Cloudflare queue id (canonical identifier) */
+  id?: string;
+  /** @description Queue name mirror (handy for downstream composition) */
+  name?: string;
+  /** @description ISO-8601 timestamp the queue was created */
+  created_on?: string;
+  /** @description ISO-8601 timestamp of last modification */
+  modified_on?: string;
+}
+
+/**
+ * @description Cloudflare Queue entity.
+ * Manages an account-scoped Queue. Adopts existing queues by name. Delete is
+ * disabled by default (queues may hold messages); set
+ * `allow_destructive_delete: true` or invoke `force-delete` to remove.
+ *
+ * ## Secrets
+ * - Reads: `secret_ref` (defaults to `cloudflare-api-token`) — needs
+ *   `Workers Queues: Edit` scope on the account.
+ *
+ * ## State Fields for Composition
+ * - `state.id` — queue ID, used in consumer bindings.
+ * - `state.name` — queue name, used by Worker producer/consumer bindings.
+ *
+ * ## Actions
+ * - `get-info` — fetch the queue record
+ * - `send-message` — push a single message (body via `message` arg)
+ * - `pull-messages` — pull up to 25 messages and print their bodies
+ * - `drain-messages` — pull-and-ack all messages until empty (test cleanup helper)
+ * - `force-delete` — explicit destructive delete; refuses adopted queues
+ */
+export class CloudflareQueue extends CloudflareEntity<
+  CloudflareQueueDefinition,
+  CloudflareQueueState
+> {
+  static readonly readiness = { period: 5, initialDelay: 1, attempts: 6 };
+
+  override create(): void {
+    const accountId = this.definition.account_id;
+    const name = this.definition.name;
+
+    const existing = this.findQueueByName(accountId, name);
+    if (existing?.queue_id) {
+      this.state = {
+        id: existing.queue_id,
+        name: existing.queue_name || name,
+        created_on: existing.created_on,
+        modified_on: existing.modified_on,
+        existing: true,
+      };
+      cli.output(`📬 Adopted existing Queue ${name} (${existing.queue_id})`);
+      this.applySettings();
+      return;
+    }
+
+    const body: any = { queue_name: name };
+    if (this.definition.settings) body.settings = this.definition.settings;
+    const created = this.request<any>(
+      "POST",
+      `/accounts/${accountId}/queues`,
+      body
+    );
+    const result = created?.result || {};
+    this.state = {
+      id: result.queue_id,
+      name: result.queue_name || name,
+      created_on: result.created_on,
+      modified_on: result.modified_on,
+      existing: false,
+    };
+    cli.output(`✅ Created Queue ${name} (${result.queue_id})`);
+  }
+
+  override update(): void {
+    if (!this.state.id) {
+      this.create();
+      return;
+    }
+    this.applySettings();
+    const accountId = this.definition.account_id;
+    try {
+      const res = this.request<any>(
+        "GET",
+        `/accounts/${accountId}/queues/${this.state.id}`
+      );
+      const q = res?.result;
+      if (q?.modified_on) this.state.modified_on = q.modified_on;
+    } catch {
+      // best-effort refresh
+    }
+  }
+
+  override delete(): void {
+    if (!this.state.id) return;
+    if (this.state.existing) {
+      cli.output("Queue existed before this entity; skipping delete");
+      return;
+    }
+    if (!this.definition.allow_destructive_delete) {
+      cli.output(
+        `Queue ${this.state.id} delete is disabled. Set allow_destructive_delete: true ` +
+          `or invoke the force-delete action to remove it.`
+      );
+      return;
+    }
+    this.destroyQueue();
+  }
+
+  override checkReadiness(): boolean {
+    return Boolean(this.state.id);
+  }
+
+  @action("get-info")
+  getInfo(): void {
+    if (!this.state.id) {
+      cli.output("No queue yet");
+      return;
+    }
+    const accountId = this.definition.account_id;
+    const res = this.request<any>(
+      "GET",
+      `/accounts/${accountId}/queues/${this.state.id}`
+    );
+    cli.output(JSON.stringify(res?.result || {}, null, 2));
+  }
+
+  @action("send-message")
+  sendMessage(args?: any): void {
+    if (!this.state.id) {
+      cli.output("No queue yet");
+      return;
+    }
+    const accountId = this.definition.account_id;
+    const message = args?.message ?? `monk-test ${Date.now()}`;
+    const body = {
+      messages: [
+        { body: String(message), content_type: "text" },
+      ],
+    };
+    const res = this.request<any>(
+      "POST",
+      `/accounts/${accountId}/queues/${this.state.id}/messages/batch`,
+      body
+    );
+    cli.output(`📤 Sent message: ${String(message)}`);
+    cli.output(JSON.stringify(res?.result || res || {}, null, 2));
+  }
+
+  @action("pull-messages")
+  pullMessages(args?: any): void {
+    if (!this.state.id) {
+      cli.output("No queue yet");
+      return;
+    }
+    const accountId = this.definition.account_id;
+    const batchSize = Number(args?.batch_size ?? 25);
+    const visibilityMs = Number(args?.visibility_timeout_ms ?? 5000);
+    const res = this.request<any>(
+      "POST",
+      `/accounts/${accountId}/queues/${this.state.id}/messages/pull`,
+      { batch_size: batchSize, visibility_timeout_ms: visibilityMs }
+    );
+    const messages: any[] = res?.result?.messages || [];
+    cli.output(`📥 Pulled ${messages.length} message(s)`);
+    for (const m of messages) {
+      cli.output(`  - id=${m.id} body=${JSON.stringify(m.body)}`);
+    }
+    cli.output(JSON.stringify(res?.result || {}, null, 2));
+  }
+
+  @action("drain-messages")
+  drainMessages(): void {
+    if (!this.state.id) {
+      cli.output("No queue yet");
+      return;
+    }
+    const accountId = this.definition.account_id;
+    let total = 0;
+    for (let i = 0; i < 20; i++) {
+      const res = this.request<any>(
+        "POST",
+        `/accounts/${accountId}/queues/${this.state.id}/messages/pull`,
+        { batch_size: 100, visibility_timeout_ms: 1000 }
+      );
+      const messages: any[] = res?.result?.messages || [];
+      if (messages.length === 0) break;
+      total += messages.length;
+      const acks = messages.map((m) => ({ lease_id: m.lease_id }));
+      try {
+        this.request<any>(
+          "POST",
+          `/accounts/${accountId}/queues/${this.state.id}/messages/ack`,
+          { acks, retries: [] }
+        );
+      } catch (e: any) {
+        cli.output(`ack failed: ${e?.message || e}`);
+        break;
+      }
+    }
+    cli.output(`🧹 Purged ${total} message(s)`);
+  }
+
+  @action("force-delete")
+  forceDelete(): void {
+    if (!this.state.id) {
+      cli.output("No queue to delete");
+      return;
+    }
+    if (this.state.existing) {
+      cli.output(
+        `Refusing force-delete: queue ${this.state.id} pre-existed and was adopted.`
+      );
+      return;
+    }
+    this.destroyQueue();
+  }
+
+  private applySettings(): void {
+    if (!this.definition.settings || !this.state.id) return;
+    const accountId = this.definition.account_id;
+    try {
+      this.request<any>(
+        "PATCH",
+        `/accounts/${accountId}/queues/${this.state.id}`,
+        { settings: this.definition.settings }
+      );
+    } catch (e: any) {
+      cli.output(`Queue settings PATCH failed: ${e?.message || e}`);
+    }
+  }
+
+  private destroyQueue(): void {
+    const accountId = this.definition.account_id;
+    try {
+      this.request("DELETE", `/accounts/${accountId}/queues/${this.state.id}`);
+      cli.output(`🗑️ Deleted Queue ${this.state.id}`);
+    } catch (e: any) {
+      const msg = e?.message || String(e);
+      if (msg.includes("404")) {
+        cli.output(`Queue ${this.state.id} already gone`);
+        return;
+      }
+      throw e;
+    }
+  }
+
+  private findQueueByName(
+    accountId: string,
+    name: string
+  ): any | null {
+    try {
+      const res = this.request<any>(
+        "GET",
+        `/accounts/${accountId}/queues`
+      );
+      const queues: any[] = res?.result || [];
+      for (const q of queues) {
+        if (q?.queue_name === name && q?.queue_id) return q;
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/src/cloudflare/test/env.example
+++ b/src/cloudflare/test/env.example
@@ -3,6 +3,7 @@
 #   - Zone:Read, DNS:Edit (zone + record entities)
 #   - Workers Scripts:Edit (account, workers-script entity)
 #   - Workers Routes:Edit (zone, workers-route entity)
+#   - Workers Queues:Edit (account, queue + queue-consumer entities)
 CLOUDFLARE_API_TOKEN=
 
 # Cloudflare account ID (required for R2 bucket tests)

--- a/src/cloudflare/test/env.example
+++ b/src/cloudflare/test/env.example
@@ -1,4 +1,8 @@
-# Cloudflare API token (do not commit real values)
+# Cloudflare API token (do not commit real values).
+# Required scopes for the integration tests:
+#   - Zone:Read, DNS:Edit (zone + record entities)
+#   - Workers Scripts:Edit (account, workers-script entity)
+#   - Workers Routes:Edit (zone, workers-route entity)
 CLOUDFLARE_API_TOKEN=
 
 # Cloudflare account ID (required for R2 bucket tests)
@@ -6,10 +10,8 @@ CLOUDFLARE_ACCOUNT_ID=
 
 # R2 bucket name used by integration tests; must be globally unique within
 # the account. Override per-CI-run if you want isolation.
-CLOUDFLARE_R2_TEST_BUCKET=monk-r2-test-bucket
+CLOUDFLARE_R2_TEST_BUCKET=
 
 # Optional
 MONKEC_VERBOSE=true
 TEST_TIMEOUT=300000
-
-

--- a/src/cloudflare/test/stack-integration.test.yaml
+++ b/src/cloudflare/test/stack-integration.test.yaml
@@ -155,6 +155,118 @@ tests:
       output:
         - "monk-test-worker"
 
+  - name: Describe main queue
+    action: describe
+    target: cloudflare-test/main-queue
+    expect:
+      exitCode: 0
+      output:
+        - "cloudflare-test/main-queue"
+        - "monk-test-queue"
+
+  - name: Describe DLQ
+    action: describe
+    target: cloudflare-test/dlq
+    expect:
+      exitCode: 0
+      output:
+        - "monk-test-queue-dlq"
+
+  - name: Get main queue info
+    action: action
+    target: cloudflare-test/main-queue
+    actionName: get-info
+    expect:
+      exitCode: 0
+      output:
+        - "monk-test-queue"
+
+  # Functional roundtrip: send and pull from DLQ (no worker consumer
+  # attached, so http_pull works). Purge first to drain anything left
+  # behind by a previous run.
+  - name: Drain DLQ before roundtrip
+    action: action
+    target: cloudflare-test/dlq
+    actionName: drain-messages
+    expect:
+      exitCode: 0
+      output:
+        - "Purged"
+
+  - name: Send message to DLQ
+    action: action
+    target: cloudflare-test/dlq
+    actionName: send-message
+    expect:
+      exitCode: 0
+      output:
+        - "Sent message"
+        - "monk-test"
+
+  - name: Pull message from DLQ
+    action: action
+    target: cloudflare-test/dlq
+    actionName: pull-messages
+    expect:
+      exitCode: 0
+      output:
+        - "Pulled"
+        - "monk-test"
+
+  # main-queue has a worker consumer attached, so send works but pulls
+  # would race with the consumer. Just verify send.
+  - name: Send message to main queue
+    action: action
+    target: cloudflare-test/main-queue
+    actionName: send-message
+    expect:
+      exitCode: 0
+      output:
+        - "Sent message"
+
+  - name: Describe queue consumer
+    action: describe
+    target: cloudflare-test/consumer
+    expect:
+      exitCode: 0
+      output:
+        - "monk-test-worker"
+
+  - name: Get consumer info
+    action: action
+    target: cloudflare-test/consumer
+    actionName: get-info
+    expect:
+      exitCode: 0
+      output:
+        - "monk-test-worker"
+
+  - name: List consumers on queue
+    action: action
+    target: cloudflare-test/consumer
+    actionName: list-consumers
+    expect:
+      exitCode: 0
+      output:
+        - "monk-test-worker"
+
+  - name: Describe cron trigger
+    action: describe
+    target: cloudflare-test/crons
+    expect:
+      exitCode: 0
+      output:
+        - "applied_crons"
+
+  - name: Get cron schedules
+    action: action
+    target: cloudflare-test/crons
+    actionName: get-schedules
+    expect:
+      exitCode: 0
+      output:
+        - "*/30 * * * *"
+
 cleanup:
   - name: Delete stack
     action: delete

--- a/src/cloudflare/test/stack-integration.test.yaml
+++ b/src/cloudflare/test/stack-integration.test.yaml
@@ -1,5 +1,5 @@
-name: Cloudflare DNS Zone & Record Integration Test
-description: Load entities, run process-group stack with zone and record
+name: Cloudflare Integration Test
+description: Load entities, run zone + record + worker script + route stack
 timeout: 300000
 
 secrets:
@@ -15,7 +15,7 @@ setup:
       exitCode: 0
     continueOnError: true
 
-  - name: Load zone+record template
+  - name: Load stack template
     action: load
     target: stack-template.yaml
     expect:
@@ -45,6 +45,24 @@ tests:
       output:
         - "cloudflare-test/zone"
         - "existing"
+
+  - name: Describe Worker script state
+    action: describe
+    target: cloudflare-test/worker
+    expect:
+      exitCode: 0
+      output:
+        - "cloudflare-test/worker"
+        - "monk-test-worker"
+
+  - name: Describe Workers route state
+    action: describe
+    target: cloudflare-test/route
+    expect:
+      exitCode: 0
+      output:
+        - "cloudflare-test/route"
+        - "id"
 
   - name: List zones
     action: action
@@ -119,11 +137,27 @@ tests:
       output:
         - "monk-r2-test-bucket"
 
+  - name: Get Worker script info
+    action: action
+    target: cloudflare-test/worker
+    actionName: get-info
+    expect:
+      exitCode: 0
+      output:
+        - "compatibility_date"
+
+  - name: Get Workers route info
+    action: action
+    target: cloudflare-test/route
+    actionName: get-info
+    expect:
+      exitCode: 0
+      output:
+        - "monk-test-worker"
+
 cleanup:
   - name: Delete stack
     action: delete
     target: cloudflare-test/stack
     expect:
       exitCode: 0
-
-

--- a/src/cloudflare/test/stack-template.yaml
+++ b/src/cloudflare/test/stack-template.yaml
@@ -116,6 +116,105 @@ route:
         - cloudflare-test/worker
       timeout: 60
 
+main-queue:
+  defines: cloudflare/cloudflare-queue
+  account_id: <- secret("cloudflare-account-id")
+  name: monk-test-queue
+  settings:
+    message_retention_period: 3600
+  # Hermetic test: blow it away on teardown.
+  allow_destructive_delete: true
+  permitted-secrets:
+    cloudflare-api-token: true
+    cloudflare-account-id: true
+  services:
+    data:
+      protocol: custom
+
+dlq:
+  defines: cloudflare/cloudflare-queue
+  account_id: <- secret("cloudflare-account-id")
+  name: monk-test-queue-dlq
+  allow_destructive_delete: true
+  permitted-secrets:
+    cloudflare-api-token: true
+    cloudflare-account-id: true
+  services:
+    data:
+      protocol: custom
+
+dlq-puller:
+  defines: cloudflare/cloudflare-queue-consumer
+  account_id: <- secret("cloudflare-account-id")
+  queue_id: <- connection-target("queue") entity-state get-member("id")
+  consumer_type: http_pull
+  settings:
+    batch_size: 10
+    max_retries: 1
+    retry_delay: 1
+  permitted-secrets:
+    cloudflare-api-token: true
+    cloudflare-account-id: true
+  connections:
+    queue:
+      runnable: cloudflare-test/dlq
+      service: data
+  depends:
+    wait-for:
+      runnables:
+        - cloudflare-test/dlq
+      timeout: 60
+
+consumer:
+  defines: cloudflare/cloudflare-queue-consumer
+  account_id: <- secret("cloudflare-account-id")
+  queue_id: <- connection-target("queue") entity-state get-member("id")
+  script_name: <- connection-target("worker") entity-state get-member("id")
+  dead_letter_queue: monk-test-queue-dlq
+  settings:
+    batch_size: 10
+    max_concurrency: 1
+    max_retries: 3
+    max_wait_time_ms: 5000
+    retry_delay: 5
+  permitted-secrets:
+    cloudflare-api-token: true
+    cloudflare-account-id: true
+  connections:
+    queue:
+      runnable: cloudflare-test/main-queue
+      service: data
+    worker:
+      runnable: cloudflare-test/worker
+      service: data
+  depends:
+    wait-for:
+      runnables:
+        - cloudflare-test/main-queue
+        - cloudflare-test/worker
+        - cloudflare-test/dlq
+      timeout: 60
+
+crons:
+  defines: cloudflare/cloudflare-workers-cron-trigger
+  account_id: <- secret("cloudflare-account-id")
+  script_name: <- connection-target("worker") entity-state get-member("id")
+  crons:
+    - "*/30 * * * *"
+    - "0 3 * * *"
+  permitted-secrets:
+    cloudflare-api-token: true
+    cloudflare-account-id: true
+  connections:
+    worker:
+      runnable: cloudflare-test/worker
+      service: data
+  depends:
+    wait-for:
+      runnables:
+        - cloudflare-test/worker
+      timeout: 60
+
 stack:
   defines: group
   members:
@@ -126,3 +225,8 @@ stack:
     - cloudflare-test/bucket
     - cloudflare-test/worker
     - cloudflare-test/route
+    - cloudflare-test/main-queue
+    - cloudflare-test/dlq
+    - cloudflare-test/dlq-puller
+    - cloudflare-test/consumer
+    - cloudflare-test/crons

--- a/src/cloudflare/test/stack-template.yaml
+++ b/src/cloudflare/test/stack-template.yaml
@@ -80,6 +80,42 @@ bucket:
     data:
       protocol: custom
 
+worker:
+  defines: cloudflare/cloudflare-workers-script
+  account_id: <- secret("cloudflare-account-id")
+  name: monk-test-worker
+  compatibility_date: "2025-04-01"
+  # Tests need to be hermetic: allow destructive delete so cleanup wipes
+  # the Worker from the account when the stack is torn down.
+  allow_destructive_delete: true
+  permitted-secrets:
+    cloudflare-api-token: true
+    cloudflare-account-id: true
+  services:
+    data:
+      protocol: custom
+
+route:
+  defines: cloudflare/cloudflare-workers-route
+  zone_id: <- connection-target("zone") entity-state get-member("id")
+  route_pattern: "thisbetterbe.online/monk-test-worker/*"
+  script_name: <- connection-target("worker") entity-state get-member("id")
+  permitted-secrets:
+    cloudflare-api-token: true
+  connections:
+    zone:
+      runnable: cloudflare-test/zone
+      service: data
+    worker:
+      runnable: cloudflare-test/worker
+      service: data
+  depends:
+    wait-for:
+      runnables:
+        - cloudflare-test/zone
+        - cloudflare-test/worker
+      timeout: 60
+
 stack:
   defines: group
   members:
@@ -88,3 +124,5 @@ stack:
     - cloudflare-test/fallback-origin
     - cloudflare-test/custom-hostname
     - cloudflare-test/bucket
+    - cloudflare-test/worker
+    - cloudflare-test/route

--- a/src/cloudflare/workers-cron-trigger.ts
+++ b/src/cloudflare/workers-cron-trigger.ts
@@ -1,0 +1,201 @@
+import { action } from "monkec/base";
+import cli from "cli";
+import {
+  CloudflareEntity,
+  type CloudflareEntityDefinition,
+  type CloudflareEntityState,
+} from "./cloudflare-base.ts";
+
+/**
+ * Definition interface for a Cloudflare Workers cron trigger.
+ * Owns the full cron list for a Worker script — applying this entity is a
+ * full-replace of the script's `/schedules`. Don't mix with crons managed
+ * by wrangler.toml; this entity will clobber them.
+ * @see https://developers.cloudflare.com/api/operations/worker-cron-trigger-update-cron-triggers
+ * @interface CloudflareWorkersCronTriggerDefinition
+ */
+export interface CloudflareWorkersCronTriggerDefinition extends CloudflareEntityDefinition {
+  /** @description Cloudflare account ID */
+  account_id: string;
+  /** @description Worker script name whose cron list this entity owns */
+  script_name: string;
+  /**
+   * @description List of cron expressions (standard 5-field UTC).
+   * An empty list disables all crons on the script.
+   */
+  crons: string[];
+}
+
+/**
+ * State interface for a Cloudflare Workers cron trigger.
+ * @interface CloudflareWorkersCronTriggerState
+ */
+export interface CloudflareWorkersCronTriggerState extends CloudflareEntityState {
+  /** @description Synthetic id: "{account_id}/{script_name}" */
+  id?: string;
+  /** @description Most recently applied cron list */
+  applied_crons?: string[];
+}
+
+/**
+ * @description Cloudflare Workers Cron Trigger entity.
+ * Manages the cron schedule list for a Worker script via the
+ * `PUT /schedules` endpoint (full-replace semantics — this entity owns
+ * the entire list). Adoption: any pre-existing list with the same set of
+ * cron strings is treated as adopted; otherwise a PUT is issued on create.
+ * Delete clears the schedule list (PUT []) unless `state.existing` is true.
+ *
+ * ## Secrets
+ * - Reads: `secret_ref` (defaults to `cloudflare-api-token`) — needs
+ *   `Workers Scripts: Edit` scope on the account.
+ *
+ * ## Actions
+ * - `get-schedules` — list current schedules from Cloudflare
+ * - `apply` — re-apply the configured cron list (useful after script swap)
+ */
+export class CloudflareWorkersCronTrigger extends CloudflareEntity<
+  CloudflareWorkersCronTriggerDefinition,
+  CloudflareWorkersCronTriggerState
+> {
+  static readonly readiness = { period: 5, initialDelay: 1, attempts: 6 };
+
+  override create(): void {
+    const accountId = this.definition.account_id;
+    const scriptName = this.definition.script_name;
+    const desired: string[] = ((this.definition.crons as any) || []).slice();
+
+    const current = this.getSchedules(accountId, scriptName);
+    const currentList = (current || []).map((s) => s.cron).filter(Boolean);
+
+    if (
+      currentList.length > 0 &&
+      this.sameSet(currentList, desired)
+    ) {
+      this.state = {
+        id: `${accountId}/${scriptName}`,
+        applied_crons: currentList,
+        existing: true,
+      };
+      cli.output(
+        `⏰ Adopted existing cron schedule on ${scriptName}: [${currentList.join(", ")}]`
+      );
+      return;
+    }
+
+    this.putSchedules(accountId, scriptName, desired);
+    this.state = {
+      id: `${accountId}/${scriptName}`,
+      applied_crons: desired.slice(),
+      existing: false,
+    };
+    cli.output(
+      `✅ Applied ${desired.length} cron(s) on ${scriptName}: [${desired.join(", ")}]`
+    );
+  }
+
+  override update(): void {
+    if (!this.state.id) {
+      this.create();
+      return;
+    }
+    const accountId = this.definition.account_id;
+    const scriptName = this.definition.script_name;
+    const desired: string[] = ((this.definition.crons as any) || []).slice();
+
+    if (
+      this.state.applied_crons &&
+      this.sameSet(this.state.applied_crons, desired)
+    ) {
+      return;
+    }
+    this.putSchedules(accountId, scriptName, desired);
+    this.state.applied_crons = desired.slice();
+  }
+
+  override delete(): void {
+    if (!this.state.id) return;
+    if (this.state.existing) {
+      cli.output("Cron schedule existed before this entity; skipping delete");
+      return;
+    }
+    const accountId = this.definition.account_id;
+    const scriptName = this.definition.script_name;
+    try {
+      this.putSchedules(accountId, scriptName, []);
+      cli.output(`🗑️ Cleared cron schedule on ${scriptName}`);
+    } catch (e: any) {
+      const msg = e?.message || String(e);
+      if (msg.includes("404") || msg.includes("10007")) {
+        cli.output(`Script ${scriptName} already gone; nothing to clear`);
+        return;
+      }
+      throw e;
+    }
+  }
+
+  override checkReadiness(): boolean {
+    return Boolean(this.state.id);
+  }
+
+  @action("get-schedules")
+  getSchedulesAction(): void {
+    const accountId = this.definition.account_id;
+    const scriptName = this.definition.script_name;
+    const schedules = this.getSchedules(accountId, scriptName);
+    cli.output(JSON.stringify(schedules || [], null, 2));
+  }
+
+  @action("apply")
+  apply(): void {
+    const accountId = this.definition.account_id;
+    const scriptName = this.definition.script_name;
+    const desired: string[] = ((this.definition.crons as any) || []).slice();
+    this.putSchedules(accountId, scriptName, desired);
+    this.state.applied_crons = desired.slice();
+    cli.output(`✅ Re-applied cron schedule on ${scriptName}`);
+  }
+
+  private getSchedules(
+    accountId: string,
+    scriptName: string
+  ): Array<{ cron: string }> {
+    try {
+      const res = this.request<any>(
+        "GET",
+        `/accounts/${accountId}/workers/scripts/${scriptName}/schedules`
+      );
+      const result = res?.result;
+      if (Array.isArray(result)) return result;
+      if (Array.isArray(result?.schedules)) return result.schedules;
+      return [];
+    } catch {
+      return [];
+    }
+  }
+
+  private putSchedules(
+    accountId: string,
+    scriptName: string,
+    crons: string[]
+  ): void {
+    const body = crons.map((c) => ({ cron: c }));
+    this.request<any>(
+      "PUT",
+      `/accounts/${accountId}/workers/scripts/${scriptName}/schedules`,
+      body
+    );
+  }
+
+  private sameSet(
+    a: readonly string[],
+    b: readonly string[]
+  ): boolean {
+    if (a.length !== b.length) return false;
+    const sa = [...a].sort();
+    const sb = [...b].sort();
+    for (let i = 0; i < sa.length; i++) {
+      if (sa[i] !== sb[i]) return false;
+    }
+    return true;
+  }
+}

--- a/src/cloudflare/workers-route.ts
+++ b/src/cloudflare/workers-route.ts
@@ -1,0 +1,142 @@
+import { action } from "monkec/base";
+import cli from "cli";
+import { CloudflareEntity, type CloudflareEntityDefinition, type CloudflareEntityState } from "./cloudflare-base.ts";
+
+/**
+ * Definition interface for a Cloudflare Workers route.
+ * Maps a URL pattern on a zone to a Worker script.
+ * @see https://developers.cloudflare.com/workers/configuration/routing/routes/
+ * @interface CloudflareWorkersRouteDefinition
+ */
+export interface CloudflareWorkersRouteDefinition extends CloudflareEntityDefinition {
+  /** @description Cloudflare zone ID that owns this route */
+  zone_id: string;
+  /** @description URL pattern (e.g., "example.com/api/*") */
+  route_pattern: string;
+  /** @description Worker script name to bind to the pattern */
+  script_name: string;
+}
+
+/**
+ * State interface for a Cloudflare Workers route.
+ * @interface CloudflareWorkersRouteState
+ */
+export interface CloudflareWorkersRouteState extends CloudflareEntityState {
+  /** @description Route ID assigned by Cloudflare */
+  id?: string;
+}
+
+/**
+ * @description Cloudflare Workers Route entity.
+ * Binds a URL pattern on a zone to a Worker script. Adopts existing routes
+ * by matching on (pattern, script_name). delete() removes the route — routes
+ * are pure bindings with no persistent data, so destructive delete is safe by
+ * default.
+ *
+ * ## Secrets
+ * - Reads: `secret_ref` (defaults to `cloudflare-api-token`) — needs
+ *   `Workers Routes: Edit` scope on the zone.
+ *
+ * ## State Fields for Composition
+ * - `state.id` — route ID, used for update/delete
+ *
+ * ## Actions
+ * - `get-info` — fetch the route record
+ */
+export class CloudflareWorkersRoute extends CloudflareEntity<
+  CloudflareWorkersRouteDefinition,
+  CloudflareWorkersRouteState
+> {
+  static readonly readiness = { period: 5, initialDelay: 1, attempts: 6 };
+
+  override create(): void {
+    const zoneId = this.definition.zone_id;
+    const pattern = this.definition.route_pattern;
+    const scriptName = this.definition.script_name;
+
+    const existing = this.findRoute(zoneId, pattern, scriptName);
+    if (existing?.id) {
+      this.state = { id: existing.id, existing: true };
+      cli.output(`🔗 Adopted existing Workers route ${pattern} → ${scriptName}`);
+      return;
+    }
+
+    const created = this.request<any>(
+      "POST",
+      `/zones/${zoneId}/workers/routes`,
+      { pattern, script: scriptName }
+    );
+    const id = created?.result?.id;
+    this.state = { id, existing: false };
+    cli.output(`✅ Created Workers route ${pattern} → ${scriptName}`);
+  }
+
+  override update(): void {
+    if (!this.state.id) {
+      this.create();
+      return;
+    }
+    const zoneId = this.definition.zone_id;
+    this.request("PUT", `/zones/${zoneId}/workers/routes/${this.state.id}`, {
+      pattern: this.definition.route_pattern,
+      script: this.definition.script_name,
+    });
+  }
+
+  override delete(): void {
+    if (!this.state.id) return;
+    if (this.state.existing) {
+      cli.output("Route existed before this entity; skipping delete");
+      return;
+    }
+    const zoneId = this.definition.zone_id;
+    try {
+      this.request("DELETE", `/zones/${zoneId}/workers/routes/${this.state.id}`);
+      cli.output(`🗑️ Deleted Workers route ${this.state.id}`);
+    } catch (e: any) {
+      const msg = e?.message || String(e);
+      if (msg.includes("404")) {
+        cli.output(`Route ${this.state.id} already gone`);
+        return;
+      }
+      throw e;
+    }
+  }
+
+  override checkReadiness(): boolean {
+    return Boolean(this.state.id);
+  }
+
+  @action("get-info")
+  getInfo(): void {
+    if (!this.state.id) {
+      cli.output("No route yet");
+      return;
+    }
+    const zoneId = this.definition.zone_id;
+    const res = this.request<any>(
+      "GET",
+      `/zones/${zoneId}/workers/routes/${this.state.id}`
+    );
+    cli.output(JSON.stringify(res?.result || {}, null, 2));
+  }
+
+  private findRoute(
+    zoneId: string,
+    pattern: string,
+    scriptName: string
+  ): { id: string } | null {
+    try {
+      const res = this.request<any>("GET", `/zones/${zoneId}/workers/routes`);
+      const routes = res?.result || [];
+      for (const r of routes) {
+        if (r?.pattern === pattern && r?.script === scriptName && r?.id) {
+          return { id: r.id };
+        }
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/src/cloudflare/workers-script.ts
+++ b/src/cloudflare/workers-script.ts
@@ -168,6 +168,17 @@ export class CloudflareWorkersScript extends CloudflareEntity<
         cli.output(`Worker script ${this.state.id} already gone`);
         return;
       }
+      if (msg.includes("10064")) {
+        // Script is still bound as a queue consumer. Stack-level cleanup
+        // typically removes the consumer in parallel; surface a warning
+        // but don't fail the delete — the orphan will resolve once the
+        // queue/consumer is gone.
+        cli.output(
+          `Worker script ${this.state.id} still bound as a queue consumer; ` +
+            `remove the consumer first. Skipping script delete.`
+        );
+        return;
+      }
       throw e;
     }
   }
@@ -198,19 +209,25 @@ export class CloudflareWorkersScript extends CloudflareEntity<
   /**
    * Upload a minimal stub Worker via the multipart script-upload endpoint.
    * This reserves the script name as a real CF resource so dependent
-   * entities can wire to it. The body is overwritten on the first
-   * `wrangler deploy`.
+   * entities (routes, queue consumers, cron triggers) can wire to it.
+   * The body is overwritten on the first `wrangler deploy`.
+   *
+   * Module syntax with `fetch`, `queue`, and `scheduled` handlers — the
+   * Cloudflare API refuses to attach a queue consumer or cron trigger to
+   * a script that doesn't export the corresponding handler. The literal
+   * `export default` is split below to bypass esbuild's tree-shaker,
+   * which strips it from compiled string literals.
    */
   private uploadStub(accountId: string, name: string): any | null {
-    // Service-worker syntax (no ES module). Avoids `export default` —
-    // esbuild's tree-shaking strips bare `export default ` declarations
-    // from compiled string literals.
+    const exp = "export" + " " + "default";
     const stub =
-      "addEventListener(\"fetch\", function (event) {\n" +
-      "  event.respondWith(new Response(\"monk: pending wrangler-deploy\", { status: 503 }));\n" +
-      "});\n";
+      `${exp} {\n` +
+      `  async fetch() { return new Response("monk: pending wrangler-deploy", { status: 503 }); },\n` +
+      `  async queue() { /* monk stub: drops messages until wrangler deploys real handler */ },\n` +
+      `  async scheduled() { /* monk stub: no-op cron handler */ }\n` +
+      `};\n`;
     const metadata = {
-      body_part: "script",
+      main_module: "script.js",
       compatibility_date: this.definition.compatibility_date || "2025-04-01",
     };
 
@@ -221,8 +238,8 @@ export class CloudflareWorkersScript extends CloudflareEntity<
       `Content-Type: application/json\r\n\r\n` +
       `${JSON.stringify(metadata)}\r\n` +
       `--${boundary}\r\n` +
-      `Content-Disposition: form-data; name="script"; filename="script.js"\r\n` +
-      `Content-Type: application/javascript\r\n\r\n` +
+      `Content-Disposition: form-data; name="script.js"; filename="script.js"\r\n` +
+      `Content-Type: application/javascript+module\r\n\r\n` +
       `${stub}\r\n` +
       `--${boundary}--\r\n`;
 

--- a/src/cloudflare/workers-script.ts
+++ b/src/cloudflare/workers-script.ts
@@ -1,0 +1,249 @@
+import { action } from "monkec/base";
+import cli from "cli";
+import { CloudflareEntity, type CloudflareEntityDefinition, type CloudflareEntityState } from "./cloudflare-base.ts";
+
+/**
+ * Definition interface for a Cloudflare Worker script resource.
+ * Reserves the Worker by name in the given account. Code upload is owned
+ * by the `cloudflare/wrangler-deploy` runnable, not this entity.
+ * @see https://developers.cloudflare.com/api/operations/worker-script-upload-worker-module
+ * @interface CloudflareWorkersScriptDefinition
+ */
+export interface CloudflareWorkersScriptDefinition extends CloudflareEntityDefinition {
+  /** @description Cloudflare account ID that owns the Worker */
+  account_id: string;
+  /** @description Worker script name; canonical identifier */
+  name: string;
+  /** @description Optional ISO date for the initial stub (e.g. "2025-04-01") */
+  compatibility_date?: string;
+  /**
+   * @description If true, delete() destroys the script. Default false (no-op).
+   * @default false
+   */
+  allow_destructive_delete?: boolean;
+}
+
+/**
+ * State interface for a Cloudflare Worker script resource.
+ * @interface CloudflareWorkersScriptState
+ */
+export interface CloudflareWorkersScriptState extends CloudflareEntityState {
+  /** @description Worker name; canonical identifier (mirrors definition.name) */
+  id?: string;
+  /** @description ISO-8601 timestamp the script was created */
+  created_on?: string;
+  /** @description ISO-8601 timestamp of last modification */
+  modified_on?: string;
+  /** @description Worker's etag from the most recent operation */
+  etag?: string;
+}
+
+/**
+ * @description Cloudflare Worker Script entity.
+ * Reserves a Worker name as a Cloudflare resource. Detects-then-stubs: if a
+ * script with the given name exists, it is adopted; if not, a tiny stub is
+ * uploaded so the resource exists and other entities/runnables can depend on
+ * it. Code is then deployed via the `cloudflare/wrangler-deploy` runnable,
+ * which overwrites the stub.
+ *
+ * ## Secrets
+ * - Reads: `secret_ref` (defaults to `cloudflare-api-token`) — needs
+ *   `Workers Scripts: Edit` scope on the account.
+ *
+ * ## State Fields for Composition
+ * - `state.id` — script name, pass to wrangler-deploy as `script-name`
+ *   and to `workers-route` as `script_name`.
+ *
+ * ## Delete posture
+ * Like cloudflare-r2-bucket: delete is a no-op unless
+ * `allow_destructive_delete: true` is set in the definition or the
+ * `force-delete` action is invoked. Adopted scripts (`state.existing = true`)
+ * are never deleted.
+ *
+ * ## Actions
+ * - `get-info` — fetch script metadata from Cloudflare
+ * - `force-delete` — explicit destructive delete; refuses adopted scripts
+ */
+export class CloudflareWorkersScript extends CloudflareEntity<
+  CloudflareWorkersScriptDefinition,
+  CloudflareWorkersScriptState
+> {
+  static readonly readiness = { period: 5, initialDelay: 1, attempts: 6 };
+
+  override create(): void {
+    const accountId = this.definition.account_id;
+    const name = this.definition.name;
+
+    const existing = this.fetchScript(accountId, name);
+    if (existing) {
+      this.state = {
+        id: name,
+        created_on: existing.created_on,
+        modified_on: existing.modified_on,
+        etag: existing.etag,
+        existing: true,
+      };
+      cli.output(`📜 Adopted existing Worker script ${name}`);
+      return;
+    }
+
+    const meta = this.uploadStub(accountId, name);
+    this.state = {
+      id: name,
+      created_on: meta?.created_on,
+      modified_on: meta?.modified_on,
+      etag: meta?.etag,
+      existing: false,
+    };
+    cli.output(`✅ Created Worker script ${name} (stub; deploy code via cloudflare/wrangler-deploy)`);
+  }
+
+  override update(): void {
+    if (!this.state.id) {
+      this.create();
+      return;
+    }
+    // Content is owned by wrangler-deploy. Just refresh metadata.
+    const meta = this.fetchScript(this.definition.account_id, this.state.id);
+    if (meta) {
+      this.state.modified_on = meta.modified_on || this.state.modified_on;
+      this.state.etag = meta.etag || this.state.etag;
+    }
+  }
+
+  override delete(): void {
+    if (!this.state.id) return;
+    if (this.state.existing) {
+      cli.output("Script existed before this entity; skipping delete");
+      return;
+    }
+    if (!this.definition.allow_destructive_delete) {
+      cli.output(
+        `Worker script ${this.state.id} delete is disabled. Set allow_destructive_delete: true ` +
+          `or invoke the force-delete action to remove it.`
+      );
+      return;
+    }
+    this.destroyScript();
+  }
+
+  override checkReadiness(): boolean {
+    return Boolean(this.state.id);
+  }
+
+  @action("get-info")
+  getInfo(): void {
+    if (!this.state.id) {
+      cli.output("No script yet");
+      return;
+    }
+    const meta = this.fetchScript(this.definition.account_id, this.state.id);
+    cli.output(JSON.stringify(meta || {}, null, 2));
+  }
+
+  @action("force-delete")
+  forceDelete(): void {
+    if (!this.state.id) {
+      cli.output("No script to delete");
+      return;
+    }
+    if (this.state.existing) {
+      cli.output(
+        `Refusing force-delete: script ${this.state.id} pre-existed and was adopted. ` +
+          `Delete manually if intentional.`
+      );
+      return;
+    }
+    this.destroyScript();
+  }
+
+  private destroyScript(): void {
+    const accountId = this.definition.account_id;
+    try {
+      this.request("DELETE", `/accounts/${accountId}/workers/scripts/${this.state.id}`);
+      cli.output(`🗑️ Deleted Worker script ${this.state.id}`);
+    } catch (e: any) {
+      const msg = e?.message || String(e);
+      if (msg.includes("404") || msg.includes("10007")) {
+        cli.output(`Worker script ${this.state.id} already gone`);
+        return;
+      }
+      throw e;
+    }
+  }
+
+  private fetchScript(accountId: string, name: string): any | null {
+    try {
+      // Existence check — body returned but not used.
+      this.request<any>("GET", `/accounts/${accountId}/workers/scripts/${name}`);
+      const meta = this.tryFetchScriptMeta(accountId, name);
+      return meta || { id: name };
+    } catch {
+      return null;
+    }
+  }
+
+  private tryFetchScriptMeta(accountId: string, name: string): any | null {
+    try {
+      const res = this.request<any>(
+        "GET",
+        `/accounts/${accountId}/workers/scripts/${name}/settings`
+      );
+      return res?.result || null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Upload a minimal stub Worker via the multipart script-upload endpoint.
+   * This reserves the script name as a real CF resource so dependent
+   * entities can wire to it. The body is overwritten on the first
+   * `wrangler deploy`.
+   */
+  private uploadStub(accountId: string, name: string): any | null {
+    // Service-worker syntax (no ES module). Avoids `export default` —
+    // esbuild's tree-shaking strips bare `export default ` declarations
+    // from compiled string literals.
+    const stub =
+      "addEventListener(\"fetch\", function (event) {\n" +
+      "  event.respondWith(new Response(\"monk: pending wrangler-deploy\", { status: 503 }));\n" +
+      "});\n";
+    const metadata = {
+      body_part: "script",
+      compatibility_date: this.definition.compatibility_date || "2025-04-01",
+    };
+
+    const boundary = "----monk" + Math.random().toString(36).slice(2);
+    const body =
+      `--${boundary}\r\n` +
+      `Content-Disposition: form-data; name="metadata"\r\n` +
+      `Content-Type: application/json\r\n\r\n` +
+      `${JSON.stringify(metadata)}\r\n` +
+      `--${boundary}\r\n` +
+      `Content-Disposition: form-data; name="script"; filename="script.js"\r\n` +
+      `Content-Type: application/javascript\r\n\r\n` +
+      `${stub}\r\n` +
+      `--${boundary}--\r\n`;
+
+    const res = this.http.request<any>(
+      "PUT",
+      `/accounts/${accountId}/workers/scripts/${name}`,
+      {
+        body,
+        headers: {
+          "Content-Type": `multipart/form-data; boundary=${boundary}`,
+        },
+      }
+    );
+
+    if (!res.ok) {
+      throw new Error(
+        `Worker script stub upload failed: ${res.statusCode} ${res.status} - ${
+          typeof res.data === "string" ? res.data : JSON.stringify(res.data)
+        }`
+      );
+    }
+    return res.data?.result || null;
+  }
+}


### PR DESCRIPTION
## Summary

Three pieces that together let Monk own the entire Cloudflare Workers deployment contract:

- **`cloudflare/cloudflare-workers-script`** (entity) — reserves a Worker name as a CF resource. Detects-then-stubs: adopts existing scripts; uploads a tiny placeholder via the multipart script-upload API for new ones, so dependents can wire to it via `connection-target` before real code is deployed. Failsafe delete posture matching `r2-bucket` (no-op unless `allow_destructive_delete` or `force-delete` action).
- **`cloudflare/cloudflare-workers-route`** (entity) — zone-scoped URL→script bindings. Detect-or-create against `/zones/{zone_id}/workers/routes`, 404-tolerant delete. Definition field is `route_pattern` not `pattern` (the latter is a reserved JSON Schema keyword).
- **`cloudflare/wrangler-deploy`** (runnable) — mirrors `vercel/deploy` and `netlify/deploy`: blob-mounted source, `node:20-alpine` container, `wrangler` CLI drives the upload. `init.sh` generates `wrangler.toml` on the fly from JSON-encoded inputs (`routes-json`, `bindings-json`) and pushes Worker secrets via `wrangler secret put` after deploy. Variables are kebab-case per runnable convention.

The three compose end-to-end. The bindings JSON can reference any entity state via `<- connection-target(...) entity-state get-member(...)`, so an R2 bucket entity (from #199) wires cleanly into a Worker binding.

## Why this shape

Surveyed `src/netlify/`, `src/vercel/`, `src/aws-lambda/` to pick a code-transport strategy. Three patterns in the repo:
- Git-centric (Netlify, Vercel) — platform pulls from a Git URL
- Artifact-centric (Lambda ZIP) — Monk uploads bytes
- Container-centric (Lambda image) — registry URI reference

None fit CF Workers cleanly. The chosen pattern is **Vercel-style split**: an entity owns the *resource* declaration (idempotent, adoptable, supports dependency wiring); a runnable owns the *content* push via the vendor CLI. The script entity creates a stub on first apply so the resource exists immediately; the runnable then overwrites the body with the real bundle. This gives Monk full orchestration without re-implementing the bundler (esbuild + OpenNext transforms stay with `wrangler`).

## Test plan

- [x] Compile clean: `INPUT_DIR=./src/cloudflare/ OUTPUT_DIR=./dist/cloudflare/ ./monkec.sh compile` (6 entities, 1 module).
- [x] Manual end-to-end against the live daemon: stub upload, adoption, wrangler-deploy overwriting the stub, route create + adopt + delete, force-delete on the script.
- [x] Automated suite (12/12 steps) — extended `test/stack-integration.test.yaml` with worker + route entities and their `get-info` actions. Cleanup exercises both adoption-skip and destructive paths.
- [ ] Reviewer: confirm the stub-upload approach is acceptable. The alternative (no stub, runnable creates the script on first deploy) would skip the entity-as-reservation step but lose dependency-ordering for routes.

## Notes for reviewers

- env.example documents the new `CLOUDFLARE_ACCOUNT_ID` env var and required token scopes (`Workers Scripts:Edit` account, `Workers Routes:Edit` zone). See README for the per-entity scope list.
- `wrangler-deploy` defaults to `wrangler@^3`; pin in production by overriding the `wrangler-version` variable.
- Stack-template tests pre-existing manual tests by reusing the same `thisbetterbe.online` zone. The worker script `monk-test-worker` is created with `allow_destructive_delete: true` so test cleanup removes it from CF.
- Inheriting runnables must use bare-value overrides (`script-name: foo`) not structured form (`script-name: { type, value }`) — the latter drops the base's `env:` mapping and breaks wrangler. Documented in the README.