### PR TITLE
feat(cloudflare): custom-hostname + fallback-origin entities

### DIFF
--- a/src/cloudflare/README.md
+++ b/src/cloudflare/README.md
@@ -108,12 +108,60 @@ interface CloudflareTunnelApplicationDefinition {
 }
 ```
 
+### `cloudflare-custom-hostname`
+
+Manages a tenant-facing vanity hostname for Cloudflare for SaaS. Adoption-safe via `(zone_id, hostname)` lookup. Delete removes the hostname (tenant-scoped lifecycle) unless `state.existing = true`.
+
+Definition (snake_case):
+
+```ts
+interface CloudflareCustomHostnameDefinition {
+  secret_ref?: string;              // optional; defaults to cloudflare-api-token
+  zone_id: string;                  // fallback zone hosting the SaaS config
+  hostname: string;                 // tenant's vanity hostname
+  ssl_method?: "http" | "txt" | "email"; // default: http
+  ssl_type?: "dv";                  // only DV supported
+  ssl_settings?: {
+    min_tls_version?: "1.0" | "1.1" | "1.2" | "1.3";
+    http2?: "on" | "off";
+    early_hints?: "on" | "off";
+  };
+  custom_origin_server?: string;    // overrides the per-zone fallback origin
+  custom_origin_sni?: string;
+}
+```
+
+State: `{ id?, status?, ssl_status?, ssl_id?, verification_errors?, applied_custom_origin?, existing? }`.
+
+Actions: `get-info`, `trigger-revalidation`.
+
+Readiness: returns true once the hostname resource exists. ACME issuance (`ssl_status=active`) depends on the tenant pointing their DNS at the fallback zone, which Monk can't drive. Inspect `get-info` to track issuance, and call `trigger-revalidation` after DNS changes.
+
+Token scope: `SSL and Certificates: Edit` on the fallback zone. The zone must have **SSL for SaaS** enabled in the dashboard.
+
+### `cloudflare-custom-hostname-fallback-origin`
+
+Per-zone setting that all custom hostnames route to by default. Adopted when the configured origin already matches.
+
+Definition (snake_case):
+
+```ts
+interface CloudflareCustomHostnameFallbackOriginDefinition {
+  secret_ref?: string; // optional; defaults to cloudflare-api-token
+  zone_id: string;     // fallback zone
+  origin: string;      // hostname Cloudflare proxies traffic to
+}
+```
+
+State: `{ origin?, status?, errors?, existing? }`. Actions: `get-info`. Token scope: same as `cloudflare-custom-hostname`.
+
 ## Secrets
 
 - Default secret name: `cloudflare-api-token`
 - Grant with `permitted-secrets` in templates
 - Cloudflare account ID is the account tag/UUID from the dashboard URL: `/accounts/<ACCOUNT_ID>`
 - Create a Cloudflare API token with account tunnel edit and DNS edit permissions
+- For Cloudflare for SaaS entities, add `SSL and Certificates: Edit` zone-level scope
 - Tunnel token secret (`cloudflare-tunnel-token`) is created by the tunnel entity and is distinct from the API token
 
 ## Example template

--- a/src/cloudflare/custom-hostname-fallback-origin.ts
+++ b/src/cloudflare/custom-hostname-fallback-origin.ts
@@ -1,0 +1,141 @@
+import { action } from "monkec/base";
+import cli from "cli";
+import { CloudflareEntity, type CloudflareEntityDefinition, type CloudflareEntityState } from "./cloudflare-base.ts";
+
+/**
+ * Definition interface for the per-zone Cloudflare for SaaS fallback origin.
+ * @see https://developers.cloudflare.com/api/operations/custom-hostname-fallback-origin-for-a-zone-update-fallback-origin-for-custom-hostnames
+ * @interface CloudflareCustomHostnameFallbackOriginDefinition
+ */
+export interface CloudflareCustomHostnameFallbackOriginDefinition extends CloudflareEntityDefinition {
+  /** @description Fallback zone ID owning the SaaS configuration */
+  zone_id: string;
+  /** @description Fallback origin hostname (e.g., proxy.bloccarbon.com) */
+  origin: string;
+}
+
+/**
+ * State interface for the Cloudflare for SaaS fallback origin.
+ * @interface CloudflareCustomHostnameFallbackOriginState
+ */
+export interface CloudflareCustomHostnameFallbackOriginState extends CloudflareEntityState {
+  /** @description Origin currently configured (echoes definition on success) */
+  origin?: string;
+  /** @description Provisioning status reported by Cloudflare */
+  status?: string;
+  /** @description Errors reported during fallback origin provisioning */
+  errors?: string[];
+}
+
+/**
+ * @description Cloudflare for SaaS Fallback Origin entity.
+ * Configures the single per-zone fallback origin that all custom hostnames
+ * route to by default. Detects an existing setting and adopts it when the
+ * configured `origin` matches. Delete clears the fallback origin only for
+ * non-adopted state (BlocCarbon-style: set once per environment).
+ *
+ * ## Secrets
+ * - Reads: `secret_ref` (defaults to `cloudflare-api-token`) — needs
+ *   `SSL and Certificates: Edit` on the fallback zone.
+ *
+ * ## Actions
+ * - `get-info` — fetch current fallback origin record
+ */
+export class CloudflareCustomHostnameFallbackOrigin extends CloudflareEntity<
+  CloudflareCustomHostnameFallbackOriginDefinition,
+  CloudflareCustomHostnameFallbackOriginState
+> {
+  static readonly readiness = { period: 5, initialDelay: 1, attempts: 6 };
+
+  override create(): void {
+    const zoneId = this.definition.zone_id;
+    const desired = this.definition.origin;
+
+    const current = this.fetchFallback(zoneId);
+    if (current?.origin === desired) {
+      this.state = {
+        origin: current.origin,
+        status: current.status,
+        errors: current.errors,
+        existing: true,
+      };
+      cli.output(`🔗 Adopted existing fallback origin ${desired}`);
+      return;
+    }
+
+    const res = this.request<any>(
+      "PUT",
+      `/zones/${zoneId}/custom_hostnames/fallback_origin`,
+      { origin: desired }
+    );
+    const r = res?.result || {};
+    this.state = {
+      origin: r.origin || desired,
+      status: r.status,
+      errors: r.errors,
+      existing: false,
+    };
+    cli.output(`✅ Set fallback origin ${desired}`);
+  }
+
+  override update(): void {
+    if (!this.state.origin) {
+      this.create();
+      return;
+    }
+    if (this.state.origin === this.definition.origin) return;
+    const zoneId = this.definition.zone_id;
+    const res = this.request<any>(
+      "PUT",
+      `/zones/${zoneId}/custom_hostnames/fallback_origin`,
+      { origin: this.definition.origin }
+    );
+    const r = res?.result || {};
+    this.state.origin = r.origin || this.definition.origin;
+    this.state.status = r.status;
+    this.state.errors = r.errors;
+  }
+
+  override delete(): void {
+    if (!this.state.origin) return;
+    if (this.state.existing) {
+      cli.output("Fallback origin pre-existed; skipping delete");
+      return;
+    }
+    const zoneId = this.definition.zone_id;
+    try {
+      this.request("DELETE", `/zones/${zoneId}/custom_hostnames/fallback_origin`);
+      cli.output(`🗑️ Cleared fallback origin for zone ${zoneId}`);
+    } catch (e: any) {
+      const msg = e?.message || String(e);
+      if (msg.includes("404")) {
+        cli.output("Fallback origin already cleared");
+        return;
+      }
+      throw e;
+    }
+  }
+
+  override checkReadiness(): boolean {
+    return Boolean(this.state.origin);
+  }
+
+  @action("get-info")
+  getInfo(): void {
+    const zoneId = this.definition.zone_id;
+    const current = this.fetchFallback(zoneId);
+    cli.output(JSON.stringify(current || {}, null, 2));
+  }
+
+  private fetchFallback(zoneId: string): any | null {
+    try {
+      const res = this.request<any>(
+        "GET",
+        `/zones/${zoneId}/custom_hostnames/fallback_origin`
+      );
+      return res?.result || null;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/src/cloudflare/custom-hostname.ts
+++ b/src/cloudflare/custom-hostname.ts
@@ -1,0 +1,229 @@
+import { action } from "monkec/base";
+import cli from "cli";
+import { CloudflareEntity, type CloudflareEntityDefinition, type CloudflareEntityState } from "./cloudflare-base.ts";
+
+/**
+ * Definition interface for a Cloudflare for SaaS custom hostname.
+ * @see https://developers.cloudflare.com/api/operations/custom-hostname-for-a-zone-create-custom-hostname
+ * @interface CloudflareCustomHostnameDefinition
+ */
+export interface CloudflareCustomHostnameDefinition extends CloudflareEntityDefinition {
+  /** @description Fallback zone ID owning the SaaS configuration */
+  zone_id: string;
+  /** @description Tenant's vanity hostname (e.g., carbon.acme.com) */
+  hostname: string;
+  /** @description ACME validation method; default http */
+  ssl_method?: "http" | "txt" | "email";
+  /** @description Certificate type; only DV is supported */
+  ssl_type?: "dv";
+  /** @description Optional SSL settings overrides */
+  ssl_settings?: {
+    min_tls_version?: "1.0" | "1.1" | "1.2" | "1.3";
+    http2?: "on" | "off";
+    early_hints?: "on" | "off";
+  };
+  /** @description Custom origin to route requests to (overrides fallback origin) */
+  custom_origin_server?: string;
+  /** @description SNI to send to the custom origin */
+  custom_origin_sni?: string;
+}
+
+/**
+ * State interface for a Cloudflare custom hostname.
+ * @interface CloudflareCustomHostnameState
+ */
+export interface CloudflareCustomHostnameState extends CloudflareEntityState {
+  /** @description Cloudflare custom hostname ID */
+  id?: string;
+  /** @description Hostname-level status (pending|active|blocked|moved) */
+  status?: string;
+  /** @description SSL provisioning status */
+  ssl_status?: string;
+  /** @description Cloudflare-side SSL record ID */
+  ssl_id?: string;
+  /** @description Most recent verification errors surfaced by the API */
+  verification_errors?: string[];
+  /** @description Applied custom origin (used for change detection) */
+  applied_custom_origin?: string;
+}
+
+/**
+ * @description Cloudflare for SaaS / Custom Hostname entity.
+ * Manages a tenant-facing vanity hostname on a fallback zone. Adoption-safe:
+ * existing hostnames are picked up by matching on `hostname`. Delete removes
+ * the hostname (tenant-scoped lifecycle), but skips adopted records.
+ *
+ * Readiness intentionally returns true once `state.id` is set — ACME issuance
+ * depends on the tenant's CNAME being in place, which is outside Monk's
+ * control. Use the `get-info` action to inspect `ssl_status` and the
+ * `trigger-revalidation` action to force a recheck after DNS changes.
+ *
+ * ## Secrets
+ * - Reads: `secret_ref` (defaults to `cloudflare-api-token`) — needs
+ *   `SSL and Certificates: Edit` on the fallback zone.
+ *
+ * ## Actions
+ * - `get-info` — fetch current hostname + SSL state from Cloudflare
+ * - `trigger-revalidation` — force the SaaS layer to re-check DNS/ACME
+ */
+export class CloudflareCustomHostname extends CloudflareEntity<
+  CloudflareCustomHostnameDefinition,
+  CloudflareCustomHostnameState
+> {
+  static readonly readiness = { period: 5, initialDelay: 1, attempts: 6 };
+
+  override create(): void {
+    const zoneId = this.definition.zone_id;
+    const hostname = this.definition.hostname;
+
+    const existing = this.findHostname(zoneId, hostname);
+    if (existing?.id) {
+      this.state = {
+        id: existing.id,
+        status: existing.status,
+        ssl_status: existing.ssl?.status,
+        ssl_id: existing.ssl?.id,
+        applied_custom_origin: existing.custom_origin_server,
+        existing: true,
+      };
+      cli.output(`🔗 Adopted existing custom hostname ${hostname}`);
+      return;
+    }
+
+    const created = this.request<any>(
+      "POST",
+      `/zones/${zoneId}/custom_hostnames`,
+      this.buildPayload()
+    );
+    const r = created?.result || {};
+    this.state = {
+      id: r.id,
+      status: r.status,
+      ssl_status: r.ssl?.status,
+      ssl_id: r.ssl?.id,
+      verification_errors: r.verification_errors,
+      applied_custom_origin: r.custom_origin_server,
+      existing: false,
+    };
+    cli.output(`✅ Created custom hostname ${hostname} (ssl ${r.ssl?.status || "pending"})`);
+  }
+
+  override update(): void {
+    if (!this.state.id) {
+      this.create();
+      return;
+    }
+    const zoneId = this.definition.zone_id;
+    const res = this.request<any>(
+      "PATCH",
+      `/zones/${zoneId}/custom_hostnames/${this.state.id}`,
+      this.buildPayload()
+    );
+    const r = res?.result || {};
+    this.state.status = r.status || this.state.status;
+    this.state.ssl_status = r.ssl?.status || this.state.ssl_status;
+    this.state.ssl_id = r.ssl?.id || this.state.ssl_id;
+    this.state.verification_errors = r.verification_errors;
+    this.state.applied_custom_origin = r.custom_origin_server;
+  }
+
+  override delete(): void {
+    if (!this.state.id) return;
+    if (this.state.existing) {
+      cli.output("Custom hostname existed before this entity; skipping delete");
+      return;
+    }
+    const zoneId = this.definition.zone_id;
+    try {
+      this.request("DELETE", `/zones/${zoneId}/custom_hostnames/${this.state.id}`);
+      cli.output(`🗑️ Deleted custom hostname ${this.state.id}`);
+    } catch (e: any) {
+      const msg = e?.message || String(e);
+      if (msg.includes("404") || msg.includes("1436")) {
+        cli.output(`Custom hostname ${this.state.id} already gone`);
+        return;
+      }
+      throw e;
+    }
+  }
+
+  override checkReadiness(): boolean {
+    // ACME completion depends on the tenant's CNAME, which is outside our
+    // control. Treat "the resource exists" as ready and let operators
+    // monitor ssl_status via get-info.
+    return Boolean(this.state.id);
+  }
+
+  @action("get-info")
+  getInfo(): void {
+    if (!this.state.id) {
+      cli.output("No custom hostname yet");
+      return;
+    }
+    const zoneId = this.definition.zone_id;
+    const res = this.request<any>(
+      "GET",
+      `/zones/${zoneId}/custom_hostnames/${this.state.id}`
+    );
+    const r = res?.result || {};
+    this.state.status = r.status || this.state.status;
+    this.state.ssl_status = r.ssl?.status || this.state.ssl_status;
+    this.state.verification_errors = r.verification_errors;
+    cli.output(JSON.stringify(r, null, 2));
+  }
+
+  @action("trigger-revalidation")
+  triggerRevalidation(): void {
+    if (!this.state.id) {
+      cli.output("No custom hostname to revalidate");
+      return;
+    }
+    const zoneId = this.definition.zone_id;
+    // Cloudflare's documented re-validation trigger is a PATCH with an
+    // ssl block that has the same method/type — it re-arms the cert
+    // issuance state machine without changing config.
+    this.request("PATCH", `/zones/${zoneId}/custom_hostnames/${this.state.id}`, {
+      ssl: {
+        method: this.definition.ssl_method || "http",
+        type: this.definition.ssl_type || "dv",
+      },
+    });
+    cli.output(`🔁 Triggered revalidation for ${this.definition.hostname}`);
+  }
+
+  private buildPayload(): any {
+    const payload: any = {
+      hostname: this.definition.hostname,
+      ssl: {
+        method: this.definition.ssl_method || "http",
+        type: this.definition.ssl_type || "dv",
+      },
+    };
+    if (this.definition.ssl_settings) {
+      payload.ssl.settings = this.definition.ssl_settings;
+    }
+    if (this.definition.custom_origin_server) {
+      payload.custom_origin_server = this.definition.custom_origin_server;
+    }
+    if (this.definition.custom_origin_sni) {
+      payload.custom_origin_sni = this.definition.custom_origin_sni;
+    }
+    return payload;
+  }
+
+  private findHostname(zoneId: string, hostname: string): any | null {
+    try {
+      const res = this.request<any>(
+        "GET",
+        `/zones/${zoneId}/custom_hostnames?hostname=${encodeURIComponent(hostname)}`
+      );
+      const list = res?.result || [];
+      for (const r of list) {
+        if (r?.hostname === hostname && r?.id) return r;
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/src/cloudflare/example-custom-hostname.yaml
+++ b/src/cloudflare/example-custom-hostname.yaml
@@ -1,0 +1,62 @@
+namespace: cloudflare-saas-example
+
+# Cloudflare for SaaS / Custom Hostnames example.
+#
+# Prerequisites:
+#   - The fallback zone (e.g. cf.bloccarbon.com) is registered in your CF
+#     account and the "SSL for SaaS" feature is enabled on it.
+#   - Your API token has `SSL and Certificates: Edit` on the zone.
+#   - Tenant DNS (carbon.acme.com) CNAMEs to your fallback zone so ACME
+#     validation can complete after Monk has provisioned the hostname.
+
+zone:
+  defines: cloudflare/cloudflare-dns-zone
+  name: cf.bloccarbon.com
+  permitted-secrets:
+    cloudflare-api-token: true
+  services:
+    data:
+      protocol: custom
+
+# Set once per environment. All custom hostnames default-route to this
+# origin unless they override with custom_origin_server.
+fallback-origin:
+  defines: cloudflare/cloudflare-custom-hostname-fallback-origin
+  zone_id: <- connection-target("zone") entity-state get-member("id")
+  origin: proxy.bloccarbon.com
+  permitted-secrets:
+    cloudflare-api-token: true
+  connections:
+    zone:
+      runnable: cloudflare-saas-example/zone
+      service: data
+  depends:
+    wait-for:
+      runnables:
+        - cloudflare-saas-example/zone
+      timeout: 60
+
+# Per-tenant vanity hostname. ssl_status will sit at pending_validation
+# until the tenant's CNAME is in place, at which point Cloudflare drives
+# ACME issuance to completion. Use the `trigger-revalidation` action to
+# force a recheck after the tenant updates DNS.
+tenant-hostname:
+  defines: cloudflare/cloudflare-custom-hostname
+  zone_id: <- connection-target("zone") entity-state get-member("id")
+  hostname: carbon.acme.com
+  ssl_method: http
+  ssl_type: dv
+  ssl_settings:
+    min_tls_version: "1.2"
+    http2: "on"
+  permitted-secrets:
+    cloudflare-api-token: true
+  connections:
+    zone:
+      runnable: cloudflare-saas-example/zone
+      service: data
+  depends:
+    wait-for:
+      runnables:
+        - cloudflare-saas-example/fallback-origin
+      timeout: 60

--- a/src/cloudflare/test/stack-integration.test.yaml
+++ b/src/cloudflare/test/stack-integration.test.yaml
@@ -59,6 +59,47 @@ tests:
     expect:
       exitCode: 0
 
+  - name: Describe custom hostname state
+    action: describe
+    target: cloudflare-test/custom-hostname
+    expect:
+      exitCode: 0
+      output:
+        - "cloudflare-test/custom-hostname"
+        - "monk-test-tenant.monktest.dev"
+
+  - name: Get custom hostname info
+    action: action
+    target: cloudflare-test/custom-hostname
+    actionName: get-info
+    expect:
+      exitCode: 0
+      output:
+        - "monk-test-tenant.monktest.dev"
+
+  - name: Trigger custom hostname revalidation
+    action: action
+    target: cloudflare-test/custom-hostname
+    actionName: trigger-revalidation
+    expect:
+      exitCode: 0
+
+  - name: Describe fallback origin state
+    action: describe
+    target: cloudflare-test/fallback-origin
+    expect:
+      exitCode: 0
+      output:
+        - "cloudflare-test/fallback-origin"
+        - "proxy.thisbetterbe.online"
+
+  - name: Get fallback origin info
+    action: action
+    target: cloudflare-test/fallback-origin
+    actionName: get-info
+    expect:
+      exitCode: 0
+
 cleanup:
   - name: Delete stack
     action: delete

--- a/src/cloudflare/test/stack-template.yaml
+++ b/src/cloudflare/test/stack-template.yaml
@@ -29,8 +29,47 @@ record:
         - cloudflare-test/zone
       timeout: 60
 
+fallback-origin:
+  defines: cloudflare/cloudflare-custom-hostname-fallback-origin
+  zone_id: <- connection-target("zone") entity-state get-member("id")
+  origin: proxy.thisbetterbe.online
+  permitted-secrets:
+    cloudflare-api-token: true
+  connections:
+    zone:
+      runnable: cloudflare-test/zone
+      service: data
+  depends:
+    wait-for:
+      runnables:
+        - cloudflare-test/zone
+      timeout: 60
+
+custom-hostname:
+  defines: cloudflare/cloudflare-custom-hostname
+  zone_id: <- connection-target("zone") entity-state get-member("id")
+  hostname: monk-test-tenant.monktest.dev
+  ssl_method: http
+  ssl_type: dv
+  permitted-secrets:
+    cloudflare-api-token: true
+  services:
+    data:
+      protocol: custom
+  connections:
+    zone:
+      runnable: cloudflare-test/zone
+      service: data
+  depends:
+    wait-for:
+      runnables:
+        - cloudflare-test/fallback-origin
+      timeout: 60
+
 stack:
   defines: group
   members:
     - cloudflare-test/zone
     - cloudflare-test/record
+    - cloudflare-test/fallback-origin
+    - cloudflare-test/custom-hostname


### PR DESCRIPTION
## Summary

- Adds `cloudflare-custom-hostname` — per-tenant vanity hostname for Cloudflare for SaaS. Adoption-safe by `(zone_id, hostname)`; real delete with `state.existing` honored. Readiness gates on resource existence (not ACME completion, since that depends on the tenant's CNAME). Actions: `get-info`, `trigger-revalidation`.
- Adds `cloudflare-custom-hostname-fallback-origin` — per-zone default origin all custom hostnames point at. Adopted when origin matches.
- Updates README with entity docs + token scope note (`SSL and Certificates: Edit`). Includes `example-custom-hostname.yaml` and extends the integration test stack with 5 new steps.

Closes Gap 2 from `doc/bloccarbon-required-entities.md`.

## Prerequisites

The fallback zone needs **SSL for SaaS** enabled in the Cloudflare dashboard (`SSL/TLS → Custom Hostnames`, one-time per zone). The API token needs `SSL and Certificates: Edit` on that zone.

## Test plan

- [x] Integration test against `thisbetterbe.online`: zone + record + fallback-origin + custom-hostname end-to-end, 13/13 steps pass (create, describe, get-info, trigger-revalidation, delete)
- [x] Custom hostname sits at `status=pending`, `ssl_status=initializing` as expected (no real tenant DNS pointing at the zone)
- [x] Delete clears the fallback origin and removes the hostname on stack teardown

dist/ regenerated by CI.