### PR TITLE
feat(examples): add gcp-cloudrun-multi-service example

### DIFF
--- a/examples/gcp-cloudrun-multi-service/.gitignore
+++ b/examples/gcp-cloudrun-multi-service/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env

--- a/examples/gcp-cloudrun-multi-service/MANIFEST
+++ b/examples/gcp-cloudrun-multi-service/MANIFEST
@@ -1,0 +1,4 @@
+REPO gcp-cloudrun-multi-service
+LOAD gcp-cloudrun-multi-service.yaml
+BLOBS api:api/
+BLOBS frontend:frontend/

--- a/examples/gcp-cloudrun-multi-service/README.md
+++ b/examples/gcp-cloudrun-multi-service/README.md
@@ -1,0 +1,282 @@
+# gcp-cloudrun-multi-service
+
+A production-ready Cloud Run demo showing how multiple Cloud Run **services** and a Cloud Run **job** compose into a single deployable stack — wired together through Monk entity state.
+
+## What this demonstrates
+
+| Capability | Where |
+|---|---|
+| **Service-to-service URL wiring** | `frontend.env_vars.API_URL ← api.state.url` via `entity-state get-member("url")` |
+| **Different scaling profiles** | `api` (1 CPU, conc 80) vs `frontend` (1 CPU, conc 80) — documented side-by-side in YAML |
+| **Scale-to-zero** | Both services: `min_instances: 0` (cost-efficient for bursty traffic) |
+| **Cloud Run Job** | `batch-export-job` — reads tasks from Postgres, writes CSV to GCS, exits cleanly |
+| **Pre-built Docker images** | All three runtimes use Artifact Registry images; `api/`, `frontend/`, `job/` each have a `Dockerfile` |
+| **Shared service account** | `app-sa` with least-privilege roles; all three runtimes use it |
+| **Auto-generated DB password** | `password_secret: cloudrun-multi-db-password` → stored in Monk secret |
+| **Cloud SQL + GCS wiring** | `DB_HOST ← postgres.state.address`, `BUCKET_NAME ← exports-bucket.state.name` |
+
+## Architecture
+
+```
+   Browser
+     │
+     ▼
+┌─────────────────────────────────────────────┐
+│  Frontend (Cloud Run service)               │  *.run.app
+│  Node.js · 1 CPU · 256Mi · scale-to-zero   │
+│  serves SPA — API_URL embedded at deploy    │
+└──────────────────┬──────────────────────────┘
+                   │ browser XHR
+                   ▼
+┌─────────────────────────────────────────────┐
+│  API (Cloud Run service)                    │  *.run.app
+│  Express · 1 CPU · 512Mi · scale-to-zero   │
+│  /api/tasks  CRUD                           │
+│  /api/health                                │
+│  /api/exports  list + quick CSV export      │
+└──┬──────────────────────────────────────────┘
+   │                        │
+   ▼                        ▼
+Cloud SQL Postgres     Cloud Storage
+  (taskdb)              (exports bucket)
+   ▲                        ▲
+   │                        │
+┌──┴────────────────────────┴────────────────┐
+│  Batch Export Job (Cloud Run Job)          │
+│  node:20-alpine · 1 CPU · 512Mi · on-demand│
+│  reads all tasks → writes CSV to GCS       │
+└────────────────────────────────────────────┘
+```
+
+**Key wiring**: The frontend Cloud Run service receives `API_URL` from the API service's `state.url` — a URL that doesn't exist until the API is provisioned. MonkEC resolves this at deploy time via `connection-target("api") entity-state get-member("url")`.
+
+## Prerequisites
+
+- A monk daemon with GCP provider configured:
+  ```bash
+  sudo monk cluster provider add -p gcp
+  ```
+- GCP IAM roles (least-privilege set; `roles/owner` works for dev):
+  - `roles/serviceusage.serviceUsageAdmin`
+  - `roles/iam.serviceAccountAdmin`, `roles/iam.serviceAccountUser`
+  - `roles/cloudsql.admin`
+  - `roles/run.admin`
+  - `roles/storage.admin`
+  - `roles/cloudbuild.builds.editor`
+  - `roles/artifactregistry.admin`
+- Docker + access to `monkimages.azurecr.io` (for the job image)
+
+## Step 1 — Build and push all images
+
+All three services (API, frontend, job) require Docker images in Artifact Registry. Cloud Run only accepts images from `gcr.io`, `docker.pkg.dev`, or `docker.io`.
+
+```bash
+PROJECT_ID=your-gcp-project-id
+REGION=us-central1
+AR_REPO="${REGION}-docker.pkg.dev/${PROJECT_ID}/cloud-run-source-deploy"
+
+# Create Artifact Registry repo if it doesn't exist
+gcloud artifacts repositories create cloud-run-source-deploy \
+  --repository-format=docker --location=${REGION} --project=${PROJECT_ID} 2>/dev/null || true
+
+# Authenticate Docker to Artifact Registry
+gcloud auth configure-docker ${REGION}-docker.pkg.dev
+
+cd examples/gcp-cloudrun-multi-service
+
+# Build and push all three images
+docker build -t ${AR_REPO}/gcp-cloudrun-multi-service-api:latest api/
+docker push ${AR_REPO}/gcp-cloudrun-multi-service-api:latest
+
+docker build -t ${AR_REPO}/gcp-cloudrun-multi-service-frontend:latest frontend/
+docker push ${AR_REPO}/gcp-cloudrun-multi-service-frontend:latest
+
+docker build -t ${AR_REPO}/gcp-cloudrun-multi-service-job:latest job/
+docker push ${AR_REPO}/gcp-cloudrun-multi-service-job:latest
+```
+
+Then update the three `image:` fields in `gcp-cloudrun-multi-service.yaml` to use your project ID instead of `monk-tests`.
+
+## Step 2 — Deploy
+
+```bash
+# 1. Compile entity package (first run or after entity changes)
+INPUT_DIR=./src/gcp/ OUTPUT_DIR=./dist/gcp/ ./monkec.sh compile
+
+# 2. Load entity package + example
+sudo monk load dist/gcp/MANIFEST
+sudo monk load examples/gcp-cloudrun-multi-service/MANIFEST
+
+# 3. Deploy to a cloud node (replace TAG with your node's tag)
+sudo monk run -t TAG gcp-cloudrun-multi-service/stack
+
+# Watch progress
+sudo monk ps
+```
+
+**Expected timing (clean project):**
+- `enable-apis` — ~1 min
+- `app-sa`, `exports-bucket` — < 1 min each
+- `postgres` (Cloud SQL) — **8–15 min** (longest step)
+- `task-database`, `task-db-user` — ~30 s each
+- `api`, `frontend` (Cloud Run pre-built image deploy) — ~1–2 min each
+- `batch-export-job` — < 1 min (just registers the job definition)
+
+## Step 3 — Verify
+
+### Check all entities are ready
+```bash
+sudo monk ps
+# All should show: true true
+```
+
+### Get the frontend URL
+```bash
+sudo monk describe local/gcp-cloudrun-multi-service/frontend | grep -A1 '"url"'
+# Open https://<frontend-url> in your browser
+```
+
+### Health check
+```bash
+# Get API URL
+sudo monk describe local/gcp-cloudrun-multi-service/api | grep -A1 '"url"'
+
+# Check DB connectivity
+curl https://<api-url>/api/health
+# {"ok":true,"db":"connected","bucket":"monk-cloudrun-multi-exports-1"}
+```
+
+### Smoke test the API
+```bash
+API_URL=https://<api-url>
+
+# Create tasks
+curl -X POST -H 'Content-Type: application/json' \
+  -d '{"title":"Deploy Cloud Run demo"}' $API_URL/api/tasks
+
+curl -X POST -H 'Content-Type: application/json' \
+  -d '{"title":"Test batch export job"}' $API_URL/api/tasks
+
+# List tasks
+curl $API_URL/api/tasks
+
+# Quick export via API (writes CSV to GCS directly from the API service)
+curl -X POST $API_URL/api/exports
+# {"file":"exports/tasks-2024-01-15T...csv","rows":2}
+
+# List exports in GCS
+curl $API_URL/api/exports
+```
+
+### Run the batch export job
+```bash
+# Trigger the Cloud Run Job (reads DB → writes CSV to GCS)
+sudo monk do gcp-cloudrun-multi-service/batch-export-job/execute
+
+# Monitor recent executions
+sudo monk do gcp-cloudrun-multi-service/batch-export-job/get-executions
+
+# Check cost estimate
+sudo monk do gcp-cloudrun-multi-service/batch-export-job/get-cost-estimate
+```
+
+### Service info
+```bash
+# Get API service details (URL, revision, scaling)
+sudo monk do gcp-cloudrun-multi-service/api/get-info
+
+# List frontend revisions
+sudo monk do gcp-cloudrun-multi-service/frontend/get-revisions
+```
+
+## Key wiring patterns
+
+### 1. Service-to-service URL wiring
+```yaml
+frontend:
+  defines: gcp/cloud-run-service
+  env_vars:
+    API_URL: <- connection-target("api") entity-state get-member("url")
+  connections:
+    api:
+      runnable: gcp-cloudrun-multi-service/api
+      service: api
+```
+The frontend Cloud Run service receives the API's HTTPS endpoint (`*.run.app`) from entity state — resolved at deploy time, never hardcoded.
+
+### 2. Scaling profiles side-by-side
+```yaml
+# API — I/O-bound, can handle many concurrent requests
+api:
+  cpu: "1"
+  memory: 512Mi
+  min_instances: 0    # scale to zero between requests
+  max_instances: 5    # cap spend during spikes
+  concurrency: 80     # Cloud Run default — good for async I/O
+
+# Frontend — lightweight HTML server, less CPU needed
+frontend:
+  cpu: "0.5"
+  memory: 256Mi
+  min_instances: 0
+  max_instances: 3
+  concurrency: 100    # higher — serving static content is cheaper per request
+```
+
+### 3. Cloud Run Job vs Service
+```yaml
+# Service: long-running HTTP server
+api:
+  defines: gcp/cloud-run-service
+  port: 8080
+  min_instances: 0
+  max_instances: 5
+
+# Job: runs to completion, no HTTP port, on-demand
+batch-export-job:
+  defines: gcp/cloud-run-job
+  # No port, no min/max_instances — different paradigm
+  task_count: 1
+  max_retries: 1
+  timeout_seconds: 300
+```
+
+### 4. Shared service account
+```yaml
+app-sa:
+  defines: gcp/service-account
+  roles:
+    - roles/cloudsql.client      # DB access
+    - roles/storage.objectAdmin  # GCS access
+    - roles/run.invoker          # call other Cloud Run services
+    - roles/logging.logWriter    # structured logs
+
+# Both services and the job reference it:
+api:
+  service_account: <- connection-target("sa") entity-state get-member("email")
+```
+
+## Docker images
+
+All three services use pre-built Docker images in Artifact Registry. Cloud Run only accepts images from `gcr.io`, `docker.pkg.dev`, or `docker.io`. Each directory (`api/`, `frontend/`, `job/`) has a `Dockerfile`.
+
+The YAML `image:` fields reference `monk-tests` as the GCP project — replace with your own project ID before deploying to a different project. See [Step 1](#step-1--build-and-push-all-images) for full push instructions.
+
+## Customize
+
+| Want to… | Edit |
+|---|---|
+| Use a different region | `*.location` and `postgres.region` |
+| Change instance/bucket names | `postgres.name`, `exports-bucket.name` (bucket names globally unique) |
+| Always-warm API (no cold starts) | `api.min_instances: 1` |
+| Higher concurrency limit | `api.concurrency: 1000` + `api.cpu: "4"` |
+| Run multiple export tasks in parallel | `batch-export-job.task_count: N`, `batch-export-job.parallelism: M` |
+| Restrict API to internal traffic only | `api.ingress: INGRESS_TRAFFIC_INTERNAL_AND_CLOUD_LOAD_BALANCING` + remove `allow_unauthenticated` |
+
+## Cleanup
+
+```bash
+sudo monk delete --force local/gcp-cloudrun-multi-service/stack
+```
+
+Cloud SQL deletion takes ~1–2 min and the instance name cannot be reused for ~1 week. If exports exist in the bucket, delete them first or the bucket deletion will fail.

--- a/examples/gcp-cloudrun-multi-service/api/Dockerfile
+++ b/examples/gcp-cloudrun-multi-service/api/Dockerfile
@@ -1,0 +1,13 @@
+# API service for GCP Cloud Run multi-service demo
+FROM node:22-alpine
+WORKDIR /app
+RUN addgroup -g 1001 -S nodejs && adduser -S apiuser -u 1001
+COPY package.json index.js ./
+RUN npm install --omit=dev --silent && npm cache clean --force && \
+    chown -R apiuser:nodejs /app
+USER apiuser
+ENV NODE_ENV=production
+EXPOSE 8080
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD wget -qO- http://localhost:8080/api/health || exit 1
+CMD ["node", "index.js"]

--- a/examples/gcp-cloudrun-multi-service/api/index.js
+++ b/examples/gcp-cloudrun-multi-service/api/index.js
@@ -1,0 +1,217 @@
+/**
+ * Cloud Run Multi-Service Demo — API Service
+ *
+ * REST API for task management. Deployed to Cloud Run via source deploy
+ * (blob_name: api) — no Docker registry required.
+ *
+ * Routes:
+ *   GET  /api/health        — DB + GCS connectivity check
+ *   GET  /api/tasks         — List all tasks
+ *   POST /api/tasks         — Create a task { title }
+ *   PATCH  /api/tasks/:id   — Toggle completion
+ *   DELETE /api/tasks/:id   — Delete a task
+ *   GET  /api/exports       — List export files in GCS
+ *   POST /api/exports       — Write tasks CSV to GCS bucket
+ *
+ * Env vars (wired from entity state in YAML):
+ *   DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD
+ *   BUCKET_NAME
+ *   PORT (default 8080, Cloud Run sets this automatically)
+ */
+
+'use strict';
+
+const express = require('express');
+const cors = require('cors');
+const { Pool } = require('pg');
+
+const app = express();
+const PORT = parseInt(process.env.PORT || '8080', 10);
+
+// ── Database ──────────────────────────────────────────────────────────────────
+
+const pool = new Pool({
+  host: process.env.DB_HOST,
+  port: parseInt(process.env.DB_PORT || '5432', 10),
+  database: process.env.DB_NAME,
+  user: process.env.DB_USER,
+  password: process.env.DB_PASSWORD,
+  ssl: { rejectUnauthorized: false },  // Cloud SQL uses self-signed cert in demo
+  max: 5,
+  idleTimeoutMillis: 30000,
+  connectionTimeoutMillis: 5000,
+});
+
+async function initDB() {
+  const client = await pool.connect();
+  try {
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS tasks (
+        id        SERIAL PRIMARY KEY,
+        title     TEXT NOT NULL,
+        done      BOOLEAN NOT NULL DEFAULT false,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    `);
+    console.log('DB: tasks table ready');
+  } finally {
+    client.release();
+  }
+}
+
+// ── GCS helpers (uses metadata-server ADC — no extra SDK dep) ─────────────────
+
+const BUCKET_NAME = process.env.BUCKET_NAME || '';
+
+async function getGCSToken() {
+  const res = await fetch(
+    'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token',
+    { headers: { 'Metadata-Flavor': 'Google' } }
+  );
+  if (!res.ok) throw new Error(`Metadata server error: ${res.status}`);
+  const { access_token } = await res.json();
+  return access_token;
+}
+
+async function listGCSObjects(bucket) {
+  const token = await getGCSToken();
+  const res = await fetch(
+    `https://storage.googleapis.com/storage/v1/b/${encodeURIComponent(bucket)}/o`,
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+  if (!res.ok) throw new Error(`GCS list error: ${res.status}`);
+  const data = await res.json();
+  return (data.items || []).map(o => ({ name: o.name, size: o.size, updated: o.updated }));
+}
+
+async function uploadGCSObject(bucket, name, content, contentType = 'text/csv') {
+  const token = await getGCSToken();
+  const url = `https://storage.googleapis.com/upload/storage/v1/b/${encodeURIComponent(bucket)}/o?uploadType=media&name=${encodeURIComponent(name)}`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': contentType },
+    body: content,
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`GCS upload error ${res.status}: ${text}`);
+  }
+  return res.json();
+}
+
+// ── Middleware ────────────────────────────────────────────────────────────────
+
+app.use(cors());
+app.use(express.json());
+
+// ── Routes ────────────────────────────────────────────────────────────────────
+
+app.get('/api/health', async (_req, res) => {
+  try {
+    await pool.query('SELECT 1');
+    res.json({ ok: true, db: 'connected', bucket: BUCKET_NAME || '(not set)' });
+  } catch (err) {
+    res.status(503).json({ ok: false, error: err.message });
+  }
+});
+
+app.get('/api/tasks', async (_req, res) => {
+  try {
+    const { rows } = await pool.query('SELECT * FROM tasks ORDER BY created_at DESC');
+    res.json(rows);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/api/tasks', async (req, res) => {
+  const { title } = req.body;
+  if (!title?.trim()) return res.status(400).json({ error: 'title is required' });
+  try {
+    const { rows } = await pool.query(
+      'INSERT INTO tasks (title) VALUES ($1) RETURNING *',
+      [title.trim()]
+    );
+    res.status(201).json(rows[0]);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.patch('/api/tasks/:id', async (req, res) => {
+  const { id } = req.params;
+  try {
+    const { rows } = await pool.query(
+      'UPDATE tasks SET done = NOT done WHERE id = $1 RETURNING *',
+      [parseInt(id, 10)]
+    );
+    if (!rows.length) return res.status(404).json({ error: 'task not found' });
+    res.json(rows[0]);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.delete('/api/tasks/:id', async (req, res) => {
+  const { id } = req.params;
+  try {
+    const { rowCount } = await pool.query('DELETE FROM tasks WHERE id = $1', [parseInt(id, 10)]);
+    if (!rowCount) return res.status(404).json({ error: 'task not found' });
+    res.status(204).end();
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get('/api/exports', async (_req, res) => {
+  if (!BUCKET_NAME) return res.status(503).json({ error: 'BUCKET_NAME not configured' });
+  try {
+    const files = await listGCSObjects(BUCKET_NAME);
+    res.json(files);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/api/exports', async (_req, res) => {
+  if (!BUCKET_NAME) return res.status(503).json({ error: 'BUCKET_NAME not configured' });
+  try {
+    const { rows } = await pool.query('SELECT * FROM tasks ORDER BY created_at');
+    const csv = ['id,title,done,created_at']
+      .concat(rows.map(r => `${r.id},"${r.title.replace(/"/g, '""')}",${r.done},${r.created_at}`))
+      .join('\n');
+    const name = `exports/tasks-${new Date().toISOString().replace(/[:.]/g, '-')}.csv`;
+    const obj = await uploadGCSObject(BUCKET_NAME, name, csv);
+    res.status(201).json({ file: obj.name, rows: rows.length });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Root — list all endpoints
+app.get('/', (_req, res) => {
+  res.json({
+    service: 'cloudrun-multi-service-api',
+    endpoints: [
+      'GET  /api/health',
+      'GET  /api/tasks',
+      'POST /api/tasks { title }',
+      'PATCH /api/tasks/:id',
+      'DELETE /api/tasks/:id',
+      'GET  /api/exports',
+      'POST /api/exports',
+    ],
+  });
+});
+
+// ── Startup ───────────────────────────────────────────────────────────────────
+
+async function main() {
+  await initDB();
+  app.listen(PORT, () => console.log(`API listening on :${PORT}`));
+}
+
+process.on('SIGTERM', () => { pool.end(); process.exit(0); });
+process.on('SIGINT',  () => { pool.end(); process.exit(0); });
+
+main().catch(err => { console.error('Startup error:', err); process.exit(1); });

--- a/examples/gcp-cloudrun-multi-service/api/package.json
+++ b/examples/gcp-cloudrun-multi-service/api/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "cloudrun-multi-service-api",
+  "version": "1.0.0",
+  "description": "Task management REST API for GCP Cloud Run multi-service demo",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "pg": "^8.11.3"
+  }
+}

--- a/examples/gcp-cloudrun-multi-service/frontend/Dockerfile
+++ b/examples/gcp-cloudrun-multi-service/frontend/Dockerfile
@@ -1,0 +1,13 @@
+# Frontend service for GCP Cloud Run multi-service demo
+FROM node:22-alpine
+WORKDIR /app
+RUN addgroup -g 1001 -S nodejs && adduser -S webuser -u 1001
+COPY package.json index.js ./
+RUN npm install --omit=dev --silent && npm cache clean --force && \
+    chown -R webuser:nodejs /app
+USER webuser
+ENV NODE_ENV=production
+EXPOSE 3000
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD wget -qO- http://localhost:3000/health || exit 1
+CMD ["node", "index.js"]

--- a/examples/gcp-cloudrun-multi-service/frontend/index.js
+++ b/examples/gcp-cloudrun-multi-service/frontend/index.js
@@ -1,0 +1,184 @@
+/**
+ * Cloud Run Multi-Service Demo — Frontend Service
+ *
+ * Lightweight Express server that renders a task-management SPA.
+ * The API_URL env var is wired at deploy time from the API Cloud Run
+ * service's state.url — demonstrating service-to-service URL wiring.
+ *
+ * Env vars (wired from entity state in YAML):
+ *   API_URL  — HTTPS endpoint of the API Cloud Run service
+ *   PORT     — defaults to 3000 (Cloud Run sets this automatically)
+ */
+
+'use strict';
+
+const express = require('express');
+
+const app = express();
+const PORT = parseInt(process.env.PORT || '3000', 10);
+const API_URL = process.env.API_URL || '';
+
+app.get('/health', (_req, res) => res.json({ ok: true, api_url: API_URL || '(not set)' }));
+
+app.get('/', (_req, res) => {
+  // Embed API_URL in the HTML so browser JS can reach it directly.
+  // This is the Cloud Run service-to-service URL wiring pattern:
+  //   frontend Cloud Run → entity-state get-member("url") → API Cloud Run
+  res.setHeader('Content-Type', 'text/html; charset=utf-8');
+  res.send(/* html */ `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Task Manager · GCP Cloud Run Demo</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+    body { font: 15px/1.5 system-ui, sans-serif; max-width: 700px; margin: 2rem auto; padding: 0 1.2rem; background: #f9fafb; color: #111; }
+    h1 { font-size: 1.4rem; margin-bottom: .2rem; }
+    .meta { font-size: .8rem; color: #666; margin-bottom: 1.5rem; }
+    .meta code { background: #eee; padding: .1em .4em; border-radius: 3px; }
+    .card { background: #fff; border: 1px solid #e2e8f0; border-radius: 8px; padding: 1rem 1.2rem; margin-bottom: 1rem; }
+    h2 { font-size: 1rem; margin: 0 0 .8rem; }
+    .row { display: flex; gap: .5rem; margin-bottom: .8rem; }
+    input[type=text] { flex: 1; padding: .4rem .6rem; border: 1px solid #cbd5e1; border-radius: 5px; font-size: 14px; }
+    button { padding: .4rem .9rem; border: none; border-radius: 5px; font-size: 13px; cursor: pointer; }
+    .btn-primary { background: #2563eb; color: #fff; }
+    .btn-primary:hover { background: #1d4ed8; }
+    .btn-secondary { background: #e2e8f0; }
+    .btn-secondary:hover { background: #cbd5e1; }
+    .btn-danger { background: #fee2e2; color: #b91c1c; }
+    .btn-danger:hover { background: #fecaca; }
+    ul { list-style: none; padding: 0; margin: 0; }
+    li { display: flex; align-items: center; gap: .6rem; padding: .35rem 0; border-bottom: 1px solid #f1f5f9; }
+    li:last-child { border-bottom: none; }
+    .task-title { flex: 1; }
+    .task-title.done { text-decoration: line-through; color: #94a3b8; }
+    pre { background: #f1f5f9; padding: .6rem .8rem; border-radius: 5px; font-size: 12px; overflow: auto; max-height: 200px; margin: 0; }
+    .status { font-size: .8rem; padding: .2rem .5rem; border-radius: 4px; }
+    .ok { background: #dcfce7; color: #166534; }
+    .err { background: #fee2e2; color: #991b1b; }
+  </style>
+</head>
+<body>
+  <h1>📋 Task Manager</h1>
+  <p class="meta">GCP Cloud Run multi-service demo · API: <code id="api-url">${API_URL || '(loading…)'}</code> · <span id="health-badge"></span></p>
+
+  <div class="card">
+    <h2>Tasks</h2>
+    <div class="row">
+      <input type="text" id="new-task" placeholder="New task title…" />
+      <button class="btn-primary" onclick="createTask()">Add</button>
+      <button class="btn-secondary" onclick="loadTasks()">Refresh</button>
+    </div>
+    <ul id="task-list"></ul>
+  </div>
+
+  <div class="card">
+    <h2>Batch Export (Cloud Run Job)</h2>
+    <p style="font-size:.85rem;color:#555;margin:.3rem 0 .8rem">
+      The export job reads all tasks from Cloud SQL and writes a CSV to the Cloud Storage bucket.
+      Trigger it via Monk CLI: <code>sudo monk do gcp-cloudrun-multi-service/batch-export-job/execute</code>
+    </p>
+    <div class="row">
+      <button class="btn-primary" onclick="exportNow()">Quick Export (via API)</button>
+      <button class="btn-secondary" onclick="loadExports()">List Exports</button>
+    </div>
+    <pre id="exports">(click List Exports)</pre>
+  </div>
+
+  <script>
+    const API = ${JSON.stringify(API_URL)};
+
+    async function apiFetch(path, opts = {}) {
+      const res = await fetch(API + path, opts);
+      if (res.status === 204) return null;
+      return res.json();
+    }
+
+    async function checkHealth() {
+      try {
+        const h = await apiFetch('/api/health');
+        const badge = document.getElementById('health-badge');
+        badge.textContent = h.ok ? '✅ API healthy' : '❌ API unhealthy';
+        badge.className = 'status ' + (h.ok ? 'ok' : 'err');
+      } catch (e) {
+        document.getElementById('health-badge').innerHTML = '<span class="status err">❌ unreachable</span>';
+      }
+    }
+
+    async function loadTasks() {
+      try {
+        const tasks = await apiFetch('/api/tasks');
+        const ul = document.getElementById('task-list');
+        if (!tasks.length) { ul.innerHTML = '<li style="color:#94a3b8">No tasks yet.</li>'; return; }
+        ul.innerHTML = tasks.map(t => \`
+          <li>
+            <input type="checkbox" \${t.done ? 'checked' : ''} onchange="toggleTask(\${t.id})" />
+            <span class="task-title \${t.done ? 'done' : ''}">\${escHtml(t.title)}</span>
+            <small style="color:#94a3b8">#\${t.id}</small>
+            <button class="btn-danger" style="font-size:11px;padding:.2rem .5rem" onclick="deleteTask(\${t.id})">del</button>
+          </li>
+        \`).join('');
+      } catch (e) { console.error(e); }
+    }
+
+    async function createTask() {
+      const inp = document.getElementById('new-task');
+      const title = inp.value.trim();
+      if (!title) return;
+      await apiFetch('/api/tasks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title }),
+      });
+      inp.value = '';
+      loadTasks();
+    }
+
+    async function toggleTask(id) {
+      await apiFetch('/api/tasks/' + id, { method: 'PATCH' });
+      loadTasks();
+    }
+
+    async function deleteTask(id) {
+      await apiFetch('/api/tasks/' + id, { method: 'DELETE' });
+      loadTasks();
+    }
+
+    async function exportNow() {
+      document.getElementById('exports').textContent = 'Exporting…';
+      try {
+        const r = await apiFetch('/api/exports', { method: 'POST' });
+        document.getElementById('exports').textContent = JSON.stringify(r, null, 2);
+      } catch (e) {
+        document.getElementById('exports').textContent = 'Error: ' + e.message;
+      }
+    }
+
+    async function loadExports() {
+      try {
+        const files = await apiFetch('/api/exports');
+        document.getElementById('exports').textContent =
+          files.length ? JSON.stringify(files, null, 2) : '(no exports yet)';
+      } catch (e) {
+        document.getElementById('exports').textContent = 'Error: ' + e.message;
+      }
+    }
+
+    function escHtml(str) {
+      return str.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+    }
+
+    document.getElementById('new-task').addEventListener('keydown', e => { if (e.key === 'Enter') createTask(); });
+
+    checkHealth();
+    loadTasks();
+  </script>
+</body>
+</html>`);
+});
+
+app.listen(PORT, () => console.log(`Frontend listening on :${PORT} — API_URL=${API_URL || '(not set)'}`));
+
+process.on('SIGTERM', () => process.exit(0));
+process.on('SIGINT',  () => process.exit(0));

--- a/examples/gcp-cloudrun-multi-service/frontend/package.json
+++ b/examples/gcp-cloudrun-multi-service/frontend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "cloudrun-multi-service-frontend",
+  "version": "1.0.0",
+  "description": "Frontend SPA for GCP Cloud Run multi-service demo",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/examples/gcp-cloudrun-multi-service/gcp-cloudrun-multi-service.yaml
+++ b/examples/gcp-cloudrun-multi-service/gcp-cloudrun-multi-service.yaml
@@ -1,0 +1,382 @@
+# GCP Cloud Run — Multi-Service Production Demo
+#
+# A production-ready stack demonstrating the full Cloud Run capability set:
+#
+#   Browser
+#     │
+#     ▼
+#   Frontend  (Cloud Run service, pre-built Docker image)  ← scale-to-zero, 1 CPU
+#     │ browser → API_URL (wired from entity state)
+#     ▼
+#   API       (Cloud Run service, pre-built Docker image)  ← scale-to-zero, 1 CPU
+#     ├─► Cloud SQL Postgres (tasks table)
+#     └─► Cloud Storage bucket (quick CSV export)
+#
+#   Batch Export Job (Cloud Run Job, pre-built image)     ← on-demand batch processing
+#     ├─► Cloud SQL Postgres
+#     └─► Cloud Storage bucket
+#
+# Key patterns demonstrated:
+#   1. Service-to-service URL wiring: frontend.env_vars.API_URL ← api.state.url
+#   2. Different scaling profiles side-by-side (comments on each service)
+#   3. Cloud Run Job for batch workloads vs long-running services
+#   4. Source deploy (blob_name) for services via Cloud Build + Google Cloud Buildpacks
+#   5. Shared service account with least-privilege IAM roles
+#   6. Auto-generated DB password via password_secret → Monk secret
+#
+# Prerequisites:
+#   sudo monk cluster provider add -p gcp
+#   Build and push the job Docker image to Artifact Registry first (see README).
+#   API and frontend deploy from source — no Docker registry needed for those.
+#
+# Deploy:
+#   sudo monk load dist/gcp/MANIFEST
+#   sudo monk load examples/gcp-cloudrun-multi-service/MANIFEST
+#   sudo monk run -t TAG gcp-cloudrun-multi-service/stack
+#
+# Cloud SQL takes 8–15 min; Cloud Run services deploy in ~1 min with pre-built images.
+
+namespace: gcp-cloudrun-multi-service
+
+# =============================================================================
+# 1. Enable required GCP APIs
+# =============================================================================
+
+enable-apis:
+  defines: gcp/service-usage
+  apis:
+    - run.googleapis.com
+    - sqladmin.googleapis.com
+    - storage.googleapis.com
+    - iam.googleapis.com
+    - cloudbuild.googleapis.com
+    - artifactregistry.googleapis.com
+
+# =============================================================================
+# 2. Shared runtime service account
+#    Both Cloud Run services and the Cloud Run Job run as this identity.
+#    Roles follow least-privilege: only what each workload needs.
+# =============================================================================
+
+app-sa:
+  defines: gcp/service-account
+  name: cloudrun-multi-runner
+  display_name: Cloud Run multi-service demo SA
+  account_description: Shared runtime identity for API service, frontend service, and export job
+  roles:
+    - roles/cloudsql.client        # connect to Cloud SQL instances
+    - roles/storage.objectAdmin    # read/write GCS objects (for export)
+    - roles/run.invoker            # allow services to call other Cloud Run services
+    - roles/logging.logWriter      # write structured logs to Cloud Logging
+  services:
+    service-account:
+      protocol: custom
+  depends:
+    wait-for:
+      runnables:
+        - gcp-cloudrun-multi-service/enable-apis
+      timeout: 300
+
+# =============================================================================
+# 3. Cloud Storage bucket — stores CSV exports produced by the batch job
+# =============================================================================
+
+exports-bucket:
+  defines: gcp/cloud-storage
+  # Bucket names are globally unique — bump the suffix if you get a conflict
+  name: monk-cloudrun-multi-exports-1
+  location: US
+  storage_class: STANDARD
+  labels:
+    environment: example
+    owner: monk-example
+  services:
+    bucket:
+      protocol: custom
+  depends:
+    wait-for:
+      runnables:
+        - gcp-cloudrun-multi-service/enable-apis
+      timeout: 300
+
+# =============================================================================
+# 4. Cloud SQL Postgres — persistent task storage
+#    Note: allow_all opens 0.0.0.0/0 for demo simplicity.
+#    Production: use Cloud SQL Auth Proxy sidecar or VPC private IP.
+# =============================================================================
+
+postgres:
+  defines: gcp/cloud-sql-instance
+  # Instance names cannot be reused for ~1 week after deletion — bump suffix on redeploy
+  name: monk-cloudrun-multi-db-1
+  database_version: POSTGRES_15
+  tier: db-f1-micro
+  region: us-central1
+  storage_size_gb: 10
+  allow_all: true
+  deletion_protection: false
+  availability_type: ZONAL
+  services:
+    instance:
+      protocol: custom
+  depends:
+    wait-for:
+      runnables:
+        - gcp-cloudrun-multi-service/enable-apis
+      timeout: 300
+
+task-database:
+  defines: gcp/cloud-sql-database
+  instance: <- connection-target("instance") entity get-member("name")
+  name: taskdb
+  charset: UTF8
+  services:
+    database:
+      protocol: custom
+  connections:
+    instance:
+      runnable: gcp-cloudrun-multi-service/postgres
+      service: instance
+  depends:
+    wait-for:
+      runnables:
+        - gcp-cloudrun-multi-service/postgres
+      timeout: 900
+
+task-db-user:
+  defines: gcp/cloud-sql-user
+  instance: <- connection-target("instance") entity get-member("name")
+  name: taskuser
+  # password_secret names the Monk secret where a random password is stored
+  # and also auto-injected into the DB_PASSWORD env var below
+  password_secret: cloudrun-multi-db-password
+  permitted-secrets:
+    cloudrun-multi-db-password: true
+  services:
+    user:
+      protocol: custom
+  connections:
+    instance:
+      runnable: gcp-cloudrun-multi-service/postgres
+      service: instance
+  depends:
+    wait-for:
+      runnables:
+        - gcp-cloudrun-multi-service/postgres
+        - gcp-cloudrun-multi-service/task-database
+      timeout: 900
+
+# =============================================================================
+# 5. API — Cloud Run service (source deploy via blob_name)
+#
+#    Scaling profile:
+#      min_instances: 0  → scale-to-zero when idle (cost-efficient for APIs
+#                          with bursty traffic; accepts ~1s cold-start latency)
+#      max_instances: 5  → cap spend during load spikes
+#      concurrency: 80   → default Cloud Run concurrency (good for I/O-bound)
+#      cpu_idle: true    → CPU throttled between requests (default, request billing)
+#
+#    Source deploy: blob_name uploads api/ to GCS, Cloud Build uses
+#    gcr.io/k8s-skaffold/pack + gcr.io/buildpacks/builder:v1 to build
+#    and push an image to Artifact Registry — same pipeline as
+#    `gcloud run deploy --source`. No Dockerfile or registry push needed.
+# =============================================================================
+
+api:
+  defines: gcp/cloud-run-service
+  name: cloudrun-multi-api
+  location: us-central1
+  blob_name: api
+  port: 8080
+  cpu: "1"
+  memory: 512Mi
+  min_instances: 0
+  max_instances: 5
+  concurrency: 80
+  # cpu_idle: true  (default) — CPU throttled when not handling requests
+  timeout_seconds: 60
+  allow_unauthenticated: true
+  service_account: <- connection-target("sa") entity-state get-member("email")
+  labels:
+    environment: example
+    component: api
+    owner: monk-example
+  env_vars:
+    DB_HOST: <- connection-target("db-instance") entity-state get-member("address")
+    DB_PORT: "5432"
+    DB_NAME: taskdb
+    DB_USER: taskuser
+    DB_PASSWORD: <- secret("cloudrun-multi-db-password")
+    BUCKET_NAME: <- connection-target("bucket") entity-state get-member("name")
+  permitted-secrets:
+    cloudrun-multi-db-password: true
+  connections:
+    sa:
+      runnable: gcp-cloudrun-multi-service/app-sa
+      service: service-account
+    db-instance:
+      runnable: gcp-cloudrun-multi-service/postgres
+      service: instance
+    db-user:
+      runnable: gcp-cloudrun-multi-service/task-db-user
+      service: user
+    bucket:
+      runnable: gcp-cloudrun-multi-service/exports-bucket
+      service: bucket
+  services:
+    api:
+      protocol: custom
+  depends:
+    wait-for:
+      runnables:
+        - gcp-cloudrun-multi-service/postgres
+        - gcp-cloudrun-multi-service/task-database
+        - gcp-cloudrun-multi-service/task-db-user
+        - gcp-cloudrun-multi-service/exports-bucket
+        - gcp-cloudrun-multi-service/app-sa
+      timeout: 1200
+
+# =============================================================================
+# 6. Frontend — Cloud Run service (source deploy, blob_name: frontend)
+#
+#    Scaling profile:
+#      min_instances: 0  → scale-to-zero (frontend cold-starts are less
+#                          noticeable than API cold-starts for static pages)
+#      max_instances: 3  → light-weight Node server, low concurrency needed
+#      cpu: "1"          → Cloud Run requires cpu >= 1 when concurrency > 1
+#      memory: 256Mi     → minimal — pure Node.js, no heavy in-process work
+#
+#    Service-to-service URL wiring:
+#      API_URL is resolved from the api Cloud Run service's state.url at
+#      deploy time — the frontend never hard-codes the API endpoint.
+# =============================================================================
+
+frontend:
+  defines: gcp/cloud-run-service
+  name: cloudrun-multi-frontend
+  location: us-central1
+  blob_name: frontend
+  port: 3000
+  # Cloud Run requires cpu >= 1 when concurrency > 1.
+  # Use "0.5" only if you also set concurrency: 1 (single-request serving).
+  cpu: "1"
+  memory: 256Mi
+  min_instances: 0
+  max_instances: 3
+  concurrency: 80
+  timeout_seconds: 30
+  allow_unauthenticated: true
+  service_account: <- connection-target("sa") entity-state get-member("email")
+  labels:
+    environment: example
+    component: frontend
+    owner: monk-example
+  env_vars:
+    # ← Service-to-service URL wiring: frontend Cloud Run gets the API's
+    #   HTTPS endpoint from entity state, injected at deploy time.
+    API_URL: <- connection-target("api") entity-state get-member("url")
+  connections:
+    sa:
+      runnable: gcp-cloudrun-multi-service/app-sa
+      service: service-account
+    api:
+      runnable: gcp-cloudrun-multi-service/api
+      service: api
+  services:
+    frontend:
+      protocol: custom
+  depends:
+    wait-for:
+      runnables:
+        - gcp-cloudrun-multi-service/api
+        - gcp-cloudrun-multi-service/app-sa
+      timeout: 600
+
+# =============================================================================
+# 7. Batch Export Job — Cloud Run Job (pre-built Docker image)
+#
+#    Cloud Run Jobs differences vs Services:
+#      • Runs to completion (exit 0 = success, non-zero = failure + retry)
+#      • No HTTP server — no port or ingress
+#      • Triggered on-demand or by Cloud Scheduler (not continuous)
+#      • max_retries: 1 — retry once on transient failure
+#      • No concurrency, min/max_instances — job-specific parameters
+#
+#    Trigger:
+#      sudo monk do gcp-cloudrun-multi-service/batch-export-job/execute
+#
+#    Monitor executions:
+#      sudo monk do gcp-cloudrun-multi-service/batch-export-job/get-executions
+# =============================================================================
+
+batch-export-job:
+  defines: gcp/cloud-run-job
+  name: cloudrun-multi-export-job
+  location: us-central1
+  # Pre-built image: Cloud Run Jobs require an image URI (blob_name not supported).
+  # Cloud Run only accepts images from gcr.io, docker.pkg.dev, or docker.io —
+  # not from Azure Container Registry or other external registries.
+  # Build and push to Artifact Registry before first deploy — see README.
+  # Image must be in gcr.io, docker.pkg.dev, or docker.io — Azure CR is not supported.
+  # Replace YOUR_PROJECT with your GCP project ID.
+  # See README "Build Job Image" section for push instructions.
+  image: us-central1-docker.pkg.dev/monk-tests/cloud-run-source-deploy/gcp-cloudrun-multi-service-job:latest  # Replace monk-tests with your GCP project ID
+  cpu: "1"
+  memory: 512Mi
+  timeout_seconds: 300
+  max_retries: 1
+  task_count: 1
+  service_account: <- connection-target("sa") entity-state get-member("email")
+  labels:
+    environment: example
+    component: export-job
+    owner: monk-example
+  env_vars:
+    DB_HOST: <- connection-target("db-instance") entity-state get-member("address")
+    DB_PORT: "5432"
+    DB_NAME: taskdb
+    DB_USER: taskuser
+    DB_PASSWORD: <- secret("cloudrun-multi-db-password")
+    BUCKET_NAME: <- connection-target("bucket") entity-state get-member("name")
+  permitted-secrets:
+    cloudrun-multi-db-password: true
+  connections:
+    sa:
+      runnable: gcp-cloudrun-multi-service/app-sa
+      service: service-account
+    db-instance:
+      runnable: gcp-cloudrun-multi-service/postgres
+      service: instance
+    bucket:
+      runnable: gcp-cloudrun-multi-service/exports-bucket
+      service: bucket
+  depends:
+    wait-for:
+      runnables:
+        - gcp-cloudrun-multi-service/postgres
+        - gcp-cloudrun-multi-service/task-database
+        - gcp-cloudrun-multi-service/task-db-user
+        - gcp-cloudrun-multi-service/exports-bucket
+        - gcp-cloudrun-multi-service/app-sa
+      timeout: 1200
+
+# =============================================================================
+# Deploy everything
+# =============================================================================
+# sudo monk run -t TAG gcp-cloudrun-multi-service/stack
+#
+# After deploy, open the frontend URL shown in:
+#   sudo monk describe local/gcp-cloudrun-multi-service/frontend | grep url
+
+stack:
+  defines: group
+  members:
+    - gcp-cloudrun-multi-service/enable-apis
+    - gcp-cloudrun-multi-service/app-sa
+    - gcp-cloudrun-multi-service/exports-bucket
+    - gcp-cloudrun-multi-service/postgres
+    - gcp-cloudrun-multi-service/task-database
+    - gcp-cloudrun-multi-service/task-db-user
+    - gcp-cloudrun-multi-service/api
+    - gcp-cloudrun-multi-service/frontend
+    - gcp-cloudrun-multi-service/batch-export-job

--- a/examples/gcp-cloudrun-multi-service/job/Dockerfile
+++ b/examples/gcp-cloudrun-multi-service/job/Dockerfile
@@ -1,0 +1,31 @@
+# Multi-stage build for the Cloud Run Job
+# This is the only pre-built image in the demo — Cloud Run Jobs require an image URI,
+# so source-deploy via blob_name is not available for jobs.
+
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+COPY package.json ./
+RUN npm install --silent
+COPY . .
+
+# Production stage
+FROM node:20-alpine AS production
+
+WORKDIR /app
+
+# Non-root user
+RUN addgroup -g 1001 -S nodejs && adduser -S jobuser -u 1001
+
+COPY package.json ./
+RUN npm install --omit=dev --silent && npm cache clean --force
+
+COPY --from=builder /app/index.js ./
+
+RUN chown -R jobuser:nodejs /app
+USER jobuser
+
+ENV NODE_ENV=production
+
+# Cloud Run Jobs: container must exit with 0 on success
+CMD ["node", "index.js"]

--- a/examples/gcp-cloudrun-multi-service/job/index.js
+++ b/examples/gcp-cloudrun-multi-service/job/index.js
@@ -1,0 +1,68 @@
+/**
+ * Cloud Run Multi-Service Demo — Batch Export Job
+ *
+ * Cloud Run Job: reads all tasks from Cloud SQL Postgres, writes a CSV
+ * to the Cloud Storage bucket, then exits cleanly.
+ *
+ * Run with: monk do gcp-cloudrun-multi-service/batch-export-job/execute
+ * Or override at runtime:
+ *   monk do gcp-cloudrun-multi-service/batch-export-job/execute \
+ *     env='{"EXPORT_PREFIX":"custom"}'
+ *
+ * Env vars (wired from entity state in YAML):
+ *   DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD
+ *   BUCKET_NAME
+ *   EXPORT_PREFIX  — optional filename prefix (default: "exports/tasks")
+ */
+
+'use strict';
+
+const { Pool } = require('pg');
+const { Storage } = require('@google-cloud/storage');
+
+async function main() {
+  const prefix = process.env.EXPORT_PREFIX || 'exports/tasks';
+
+  // ── Database ──────────────────────────────────────────────────────────────
+  console.log('[job] Connecting to Cloud SQL…');
+  const pool = new Pool({
+    host: process.env.DB_HOST,
+    port: parseInt(process.env.DB_PORT || '5432', 10),
+    database: process.env.DB_NAME,
+    user: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+    ssl: { rejectUnauthorized: false },
+    connectionTimeoutMillis: 10000,
+  });
+
+  const { rows } = await pool.query('SELECT * FROM tasks ORDER BY created_at');
+  console.log(`[job] Fetched ${rows.length} tasks`);
+  await pool.end();
+
+  // ── Build CSV ─────────────────────────────────────────────────────────────
+  const csv = [
+    'id,title,done,created_at',
+    ...rows.map(r =>
+      `${r.id},"${String(r.title).replace(/"/g, '""')}",${r.done},${r.created_at.toISOString()}`
+    ),
+  ].join('\n') + '\n';
+
+  // ── Upload to GCS ─────────────────────────────────────────────────────────
+  const bucketName = process.env.BUCKET_NAME;
+  if (!bucketName) throw new Error('BUCKET_NAME env var is not set');
+
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const objectName = `${prefix}-${timestamp}.csv`;
+
+  console.log(`[job] Uploading to gs://${bucketName}/${objectName} …`);
+  const storage = new Storage();  // uses ADC from service account
+  const bucket = storage.bucket(bucketName);
+  await bucket.file(objectName).save(csv, { contentType: 'text/csv' });
+
+  console.log(`[job] ✅ Export complete — ${rows.length} rows → gs://${bucketName}/${objectName}`);
+}
+
+main().catch(err => {
+  console.error('[job] ❌ Export failed:', err.message);
+  process.exit(1);
+});

--- a/examples/gcp-cloudrun-multi-service/job/package-lock.json
+++ b/examples/gcp-cloudrun-multi-service/job/package-lock.json
@@ -1,0 +1,1188 @@
+{
+  "name": "cloudrun-multi-service-job",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cloudrun-multi-service-job",
+      "version": "1.0.0",
+      "dependencies": {
+        "@google-cloud/storage": "^7.7.0",
+        "pg": "^8.11.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@google-cloud/paginator": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.2.tgz",
+      "integrity": "sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "extend": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/projectify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-4.0.0.tgz",
+      "integrity": "sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/promisify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-4.0.0.tgz",
+      "integrity": "sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage": {
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.19.0.tgz",
+      "integrity": "sha512-n2FjE7NAOYyshogdc7KQOl/VZb4sneqPjWouSyia9CMDdMhRX5+RIbqalNmC7LOLzuLAN89VlF2HvG8na9G+zQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google-cloud/paginator": "^5.0.0",
+        "@google-cloud/projectify": "^4.0.0",
+        "@google-cloud/promisify": "<4.1.0",
+        "abort-controller": "^3.0.0",
+        "async-retry": "^1.3.3",
+        "duplexify": "^4.1.3",
+        "fast-xml-parser": "^5.3.4",
+        "gaxios": "^6.0.2",
+        "google-auth-library": "^9.6.3",
+        "html-entities": "^2.5.2",
+        "mime": "^3.0.0",
+        "p-limit": "^3.0.1",
+        "retry-request": "^7.0.0",
+        "teeny-request": "^9.0.0",
+        "uuid": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@types/caseless": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
+      "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/request": {
+      "version": "2.48.13",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.13.tgz",
+      "integrity": "sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.5"
+      }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "license": "MIT"
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/duplexify": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.2"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.2.0",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
+      "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.35",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gaxios/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/pg": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
+      "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "pg-connection-string": "^2.13.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.14.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/retry-request": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-7.0.2.tgz",
+      "integrity": "sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/request": "^2.48.8",
+        "extend": "^3.0.2",
+        "teeny-request": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/stream-events": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
+      "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "license": "MIT",
+      "dependencies": {
+        "stubs": "^3.0.0"
+      }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/stubs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
+      "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
+      "license": "MIT"
+    },
+    "node_modules/teeny-request": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-9.0.0.tgz",
+      "integrity": "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.9",
+        "stream-events": "^1.0.5",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/teeny-request/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/teeny-request/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/teeny-request/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/examples/gcp-cloudrun-multi-service/job/package.json
+++ b/examples/gcp-cloudrun-multi-service/job/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "cloudrun-multi-service-job",
+  "version": "1.0.0",
+  "description": "Batch export job for GCP Cloud Run multi-service demo",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "@google-cloud/storage": "^7.7.0",
+    "pg": "^8.11.3"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a production-ready multi-service Cloud Run example demonstrating how multiple Cloud Run services, a Cloud Run Job, Cloud SQL, and Cloud Storage compose into a single deployable stack via MonkEC entity wiring.
- Depends on the `blob_name` fix in #212 for source deploy to work.

## Architecture

```
Browser → Frontend (Cloud Run, blob_name: frontend)
             │ API_URL ← entity-state get-member("url")
             ▼
          API (Cloud Run, blob_name: api)
             ├─► Cloud SQL Postgres (tasks CRUD)
             └─► Cloud Storage (CSV exports)

          Batch Export Job (Cloud Run Job, pre-built image)
             ├─► Cloud SQL Postgres
             └─► Cloud Storage
```

## What this demonstrates

| Pattern | Where |
|---|---|
| Service-to-service URL wiring | `frontend.env_vars.API_URL ← api.state.url` |
| Source deploy (blob_name) | API and frontend built by Cloud Build + buildpacks |
| Cloud Run Job vs Service | Long-running service + batch job side-by-side |
| Scaling profiles | `min_instances`, `concurrency`, `cpu` documented in YAML comments |
| Shared IAM service account | `app-sa` used by API, frontend, and job |
| Auto-generated DB password | `password_secret` → Monk secret → `DB_PASSWORD` env var |

## Files

- `gcp-cloudrun-multi-service.yaml` — 9-entity stack (enable-apis, SA, bucket, Postgres ×3, API, frontend, job)
- `MANIFEST` — loads YAML + BLOBS for api/ and frontend/ source deploy
- `api/` — Express REST API (tasks CRUD, GCS export), Dockerfile
- `frontend/` — Node.js SPA server (injects API_URL at render time), Dockerfile
- `job/` — batch export job (reads Postgres → writes CSV to GCS, exits 0), Dockerfile

## Test plan
- [x] Cold-start deploy from zero: 9/9 entities `true true`
- [x] API health, task CRUD, GCS export via API
- [x] Frontend HTTP 200, `API_URL` correctly wired from entity state
- [x] Cloud Run Job `SUCCEEDED 1/1 tasks`
- [x] Total deploy time ~14 min (Cloud SQL ~10 min + two Cloud Build runs ~2 min each)