### PR TITLE
feat(mongodb-atlas): Flex support, drop M2/M5, modernize API version

### DIFF
--- a/dist/mongodb-atlas/MANIFEST
+++ b/dist/mongodb-atlas/MANIFEST
@@ -1,4 +1,4 @@
 REPO mongodb-atlas
-VERSION_HASH 3ac5fe00117f
-LOAD common.yaml atlas-base.yaml project.yaml cluster.yaml user.yaml
-RESOURCES user-sync.js project-sync.js cluster-sync.js atlas-base.js common.js
+VERSION_HASH 7c000a825997
+LOAD cluster.yaml atlas-base.yaml project.yaml user.yaml common.yaml
+RESOURCES common.js user-sync.js project-sync.js atlas-base.js cluster-sync.js

--- a/dist/mongodb-atlas/atlas-base.js
+++ b/dist/mongodb-atlas/atlas-base.js
@@ -43,8 +43,7 @@ var import_http = __toESM(require("http"));
 var import_secret = __toESM(require("secret"));
 var import_crypto = __toESM(require("crypto"));
 var BASE_URL = "https://cloud.mongodb.com/api/atlas/v2";
-var API_VERSION = "application/vnd.atlas.2023-01-01+json";
-var API_VERSION_2025 = "application/vnd.atlas.2025-03-12+json";
+var API_VERSION = "application/vnd.atlas.2025-03-12+json";
 function getToken(secretRef) {
   const now = /* @__PURE__ */ new Date();
   let cachedToken;
@@ -152,13 +151,12 @@ var MongoDBAtlasEntity = class extends import_base.MonkEntity {
    */
   makeRequest(method, path, body) {
     try {
-      const apiVersion = this.isClusterRequest(path) ? API_VERSION_2025 : API_VERSION;
       const headers = {
-        "Accept": apiVersion,
+        "Accept": API_VERSION,
         "Authorization": "Bearer " + this.apiToken
       };
       if (method.toUpperCase() !== "GET") {
-        headers["Content-Type"] = apiVersion;
+        headers["Content-Type"] = API_VERSION;
       }
       const response = this.httpClient.request(method, path, {
         body,
@@ -206,14 +204,20 @@ var MongoDBAtlasEntity = class extends import_base.MonkEntity {
       this.makeRequest("DELETE", path);
       import_cli.default.output(`Successfully deleted ${resourceName}`);
     } catch (error) {
+      if (this.isResourceGoneError(error)) {
+        import_cli.default.output(`${resourceName} already deleted (not found), treating as success`);
+        return;
+      }
       throw new Error(`Failed to delete ${resourceName}: ${error instanceof Error ? error.message : "Unknown error"}`);
     }
   }
   /**
-   * Check if the request path is for cluster operations
+   * Detect "resource already gone" errors so deletes can be idempotent.
+   * Covers HTTP 404, Atlas *_NOT_FOUND error codes, and "does not exist" messages.
    */
-  isClusterRequest(path) {
-    return path.includes("/clusters") || path.includes("/accessList");
+  isResourceGoneError(error) {
+    const msg = (error instanceof Error ? error.message : String(error)).toUpperCase();
+    return msg.includes(" 404") || msg.includes("NOT_FOUND") || msg.includes("NOT FOUND") || msg.includes("DOES NOT EXIST");
   }
 };
 // Annotate the CommonJS export names for ESM import in node:

--- a/dist/mongodb-atlas/atlas-base.yaml
+++ b/dist/mongodb-atlas/atlas-base.yaml
@@ -3,5 +3,5 @@ namespace: mongodb-atlas
 atlas-base:
   defines: module
   metadata:
-    version-hash: 3ac5fe00117f
+    version-hash: 7c000a825997
   source: <<< atlas-base.js

--- a/dist/mongodb-atlas/cluster-sync.js
+++ b/dist/mongodb-atlas/cluster-sync.js
@@ -64,16 +64,56 @@ var _Cluster = class _Cluster extends (_a = MongoDBAtlasEntity, _getBackupInfo_d
   getEntityName() {
     return this.definition.name;
   }
-  /**
-   * Check if the cluster tier is a shared tier (M0, M2, M5)
-   * Shared tiers use "TENANT" provider, dedicated tiers use direct provider name
-   */
-  isSharedTier() {
-    const sharedTiers = ["M0", "M2", "M5"];
-    return sharedTiers.includes(this.definition.instance_size);
+  /** Free tier (M0) — created on the /clusters endpoint with the TENANT provider. */
+  isFreeTier() {
+    return this.definition.instance_size === "M0";
   }
-  /** Create a new MongoDB Atlas cluster */
+  /** Flex tier — created on the dedicated /flexClusters endpoint. */
+  isFlexTier() {
+    return this.definition.instance_size === "FLEX";
+  }
+  /** Dedicated tier (M10+) — created on the /clusters endpoint with a direct provider. */
+  isDedicatedTier() {
+    return !this.isFreeTier() && !this.isFlexTier();
+  }
+  /** Collection path for this cluster's tier (Flex uses a separate endpoint). */
+  clustersCollectionPath() {
+    const base = `/groups/${this.definition.project_id}`;
+    return this.isFlexTier() ? `${base}/flexClusters` : `${base}/clusters`;
+  }
+  /** Resource path for this specific cluster. */
+  clusterResourcePath() {
+    return `${this.clustersCollectionPath()}/${this.definition.name}`;
+  }
+  /** Create a new MongoDB Atlas cluster (Flex, free, or dedicated). */
   create() {
+    if (this.isFlexTier()) {
+      this.createFlexCluster();
+    } else {
+      this.createClusterResource();
+    }
+    if (this.definition.allow_ips && this.definition.allow_ips.length > 0) {
+      this.configureIPAccessList();
+    }
+  }
+  /** Create a Flex cluster via the /flexClusters endpoint. */
+  createFlexCluster() {
+    const body = {
+      "name": this.definition.name,
+      "providerSettings": {
+        "backingProviderName": this.definition.provider,
+        "regionName": this.definition.region
+      }
+    };
+    const resObj = this.makeRequest("POST", this.clustersCollectionPath(), body);
+    this.state = {
+      // Flex clusters are identified by name; fall back to name if no id is returned.
+      id: resObj.id || resObj.name || this.definition.name,
+      name: resObj.name || this.definition.name
+    };
+  }
+  /** Create a free (M0/TENANT) or dedicated (M10+) cluster via the /clusters endpoint. */
+  createClusterResource() {
     const regionConfig = {
       "electableSpecs": {
         "instanceSize": this.definition.instance_size,
@@ -81,7 +121,7 @@ var _Cluster = class _Cluster extends (_a = MongoDBAtlasEntity, _getBackupInfo_d
       },
       "regionName": this.definition.region
     };
-    if (this.isSharedTier()) {
+    if (this.isFreeTier()) {
       regionConfig.providerName = "TENANT";
       regionConfig.backingProviderName = this.definition.provider;
     } else {
@@ -97,17 +137,14 @@ var _Cluster = class _Cluster extends (_a = MongoDBAtlasEntity, _getBackupInfo_d
         }
       ]
     };
-    if (!this.isSharedTier()) {
+    if (this.isDedicatedTier()) {
       body.backupEnabled = true;
     }
-    const resObj = this.makeRequest("POST", `/groups/${this.definition.project_id}/clusters`, body);
+    const resObj = this.makeRequest("POST", this.clustersCollectionPath(), body);
     this.state = {
       id: resObj.id,
       name: resObj.name
     };
-    if (this.definition.allow_ips && this.definition.allow_ips.length > 0) {
-      this.configureIPAccessList();
-    }
   }
   /** Configure IP access list for the cluster */
   configureIPAccessList() {
@@ -129,11 +166,11 @@ var _Cluster = class _Cluster extends (_a = MongoDBAtlasEntity, _getBackupInfo_d
       this.create();
       return;
     }
-    const clusterData = this.checkResourceExists(`/groups/${this.definition.project_id}/clusters/${this.definition.name}`);
+    const clusterData = this.checkResourceExists(this.clusterResourcePath());
     if (clusterData) {
       this.state = {
         ...this.state,
-        id: clusterData.id,
+        id: clusterData.id || this.state.id,
         name: clusterData.name,
         connection_standard: clusterData.connectionStrings?.standard,
         connection_srv: clusterData.connectionStrings?.standardSrv
@@ -145,13 +182,13 @@ var _Cluster = class _Cluster extends (_a = MongoDBAtlasEntity, _getBackupInfo_d
       cli.output("Cluster does not exist, nothing to delete");
       return;
     }
-    this.deleteResource(`/groups/${this.definition.project_id}/clusters/${this.definition.name}`, "Cluster");
+    this.deleteResource(this.clusterResourcePath(), "Cluster");
   }
   checkReadiness() {
     if (!this.state.id) {
       return false;
     }
-    const clusterData = this.checkResourceExists(`/groups/${this.definition.project_id}/clusters/${this.definition.name}`);
+    const clusterData = this.checkResourceExists(this.clusterResourcePath());
     if (!clusterData) {
       return false;
     }
@@ -163,7 +200,7 @@ var _Cluster = class _Cluster extends (_a = MongoDBAtlasEntity, _getBackupInfo_d
     return false;
   }
   checkLiveness() {
-    const clusterData = this.checkResourceExists(`/groups/${this.definition.project_id}/clusters/${this.definition.name}`);
+    const clusterData = this.checkResourceExists(this.clusterResourcePath());
     if (!clusterData) {
       throw new Error(`Cluster ${this.definition.name} not found`);
     }
@@ -183,9 +220,9 @@ var _Cluster = class _Cluster extends (_a = MongoDBAtlasEntity, _getBackupInfo_d
    * Backups are only available for M10+ (dedicated) clusters
    */
   validateBackupSupport() {
-    if (this.isSharedTier()) {
+    if (!this.isDedicatedTier()) {
       throw new Error(
-        `Backup operations are not supported for shared cluster tier ${this.definition.instance_size}. Backups require a dedicated cluster (M10 or higher).`
+        `Backup operations are not supported for cluster tier ${this.definition.instance_size}. On-demand backups require a dedicated cluster (M10 or higher). Flex clusters receive automatic snapshots that are not managed via these actions.`
       );
     }
   }
@@ -207,15 +244,15 @@ var _Cluster = class _Cluster extends (_a = MongoDBAtlasEntity, _getBackupInfo_d
       cli.output(`   Cluster Tier: ${this.definition.instance_size}`);
       cli.output(`   Provider: ${this.definition.provider}`);
       cli.output(`   Region: ${this.definition.region}`);
-      const backupSupported = !this.isSharedTier();
-      cli.output(`   Backup Supported: ${backupSupported ? "\u2705 Yes (M10+)" : "\u274C No (shared tier)"}`);
+      const backupSupported = this.isDedicatedTier();
+      cli.output(`   Backup Supported: ${backupSupported ? "\u2705 Yes (M10+)" : "\u274C No (M0/Flex)"}`);
       if (clusterData.backupEnabled !== void 0) {
         cli.output(`   Backup Enabled: ${clusterData.backupEnabled ? "\u2705 Yes" : "\u274C No"}`);
       }
       if (!backupSupported) {
         cli.output(`
 \u26A0\uFE0F  Note: Backups require a dedicated cluster (M10 or higher).`);
-        cli.output(`   Current tier ${this.definition.instance_size} is a shared tier.`);
+        cli.output(`   Current tier ${this.definition.instance_size} does not support on-demand backups.`);
       } else {
         cli.output(`
 \u{1F4CB} To create a manual snapshot:`);

--- a/dist/mongodb-atlas/cluster.yaml
+++ b/dist/mongodb-atlas/cluster.yaml
@@ -6,7 +6,7 @@ cluster:
     description: |-
       MongoDB Atlas Cluster entity.
       Creates and manages MongoDB Atlas database clusters for document storage.
-      Supports M0 (free tier), M2/M5 (shared), and M10+ (dedicated) cluster tiers.
+      Supports M0 (free tier), FLEX (Flex cluster), and M10+ (dedicated) cluster tiers.
 
       ## Secrets
       - Reads: secret name from `secret_ref` property - MongoDB Atlas service account credentials JSON
@@ -21,7 +21,7 @@ cluster:
       Works with:
       - `mongodb-atlas/user` - Create database users with role-based access
       - `mongodb-atlas/project` - The parent project containing the cluster
-    version-hash: 3ac5fe00117f
+    version-hash: 7c000a825997
   schema:
     secret_ref:
       type: string
@@ -52,8 +52,7 @@ cluster:
       type: string
       enum:
         - M0
-        - M2
-        - M5
+        - FLEX
         - M10
         - M20
         - M30
@@ -61,7 +60,10 @@ cluster:
         - M50
         - M60
         - M80
-      description: Instance size/tier
+      description: |-
+        Instance size/tier. M0 = free (shared/TENANT), FLEX = Flex cluster
+        (replaces the retired M2/M5 shared tiers), M10+ = dedicated. M2/M5 reached
+        End-of-Life on 2026-01-22 and are no longer creatable via the Atlas API.
     allow_ips:
       type: array
       items:

--- a/dist/mongodb-atlas/common.js
+++ b/dist/mongodb-atlas/common.js
@@ -31,7 +31,6 @@ var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: tru
 var common_exports = {};
 __export(common_exports, {
   API_VERSION: () => API_VERSION,
-  API_VERSION_2025: () => API_VERSION_2025,
   BASE_URL: () => BASE_URL,
   getOrganization: () => getOrganization,
   getToken: () => getToken
@@ -41,8 +40,7 @@ var import_http = __toESM(require("http"));
 var import_secret = __toESM(require("secret"));
 var import_crypto = __toESM(require("crypto"));
 var BASE_URL = "https://cloud.mongodb.com/api/atlas/v2";
-var API_VERSION = "application/vnd.atlas.2023-01-01+json";
-var API_VERSION_2025 = "application/vnd.atlas.2025-03-12+json";
+var API_VERSION = "application/vnd.atlas.2025-03-12+json";
 function getToken(secretRef) {
   const now = /* @__PURE__ */ new Date();
   let cachedToken;
@@ -129,7 +127,6 @@ function getOrganization(name, bearerToken) {
 // Annotate the CommonJS export names for ESM import in node:
 0 && (module.exports = {
   API_VERSION,
-  API_VERSION_2025,
   BASE_URL,
   getOrganization,
   getToken

--- a/dist/mongodb-atlas/common.yaml
+++ b/dist/mongodb-atlas/common.yaml
@@ -3,5 +3,5 @@ namespace: mongodb-atlas
 common:
   defines: module
   metadata:
-    version-hash: 3ac5fe00117f
+    version-hash: 7c000a825997
   source: <<< common.js

--- a/dist/mongodb-atlas/project-sync.js
+++ b/dist/mongodb-atlas/project-sync.js
@@ -76,62 +76,76 @@ var _Project = class _Project extends MongoDBAtlasEntity {
     return true;
   }
   /**
-   * Wait for all cluster deletions to complete by polling the API
+   * Count active clusters across both the standard and flex endpoints.
+   */
+  countActiveClusters() {
+    let total = 0;
+    for (const collection of _Project.CLUSTER_COLLECTIONS) {
+      try {
+        const response = this.makeRequest("GET", `/groups/${this.state.id}/${collection}`);
+        if (response && response.results) {
+          total += response.results.length;
+        }
+      } catch (_error) {
+      }
+    }
+    return total;
+  }
+  /**
+   * Wait for all cluster deletions (standard + flex) to complete by polling the API
    */
   waitForClusterDeletions() {
     const maxAttempts = 30;
     let attempts = 0;
     while (attempts < maxAttempts) {
-      try {
-        const clustersResponse = this.makeRequest("GET", `/groups/${this.state.id}/clusters`);
-        if (!clustersResponse || !clustersResponse.results || clustersResponse.results.length === 0) {
-          cli.output("All clusters have been deleted successfully");
-          return;
-        }
-        const remainingClusters = clustersResponse.results.length;
-        cli.output(`Still waiting for ${remainingClusters} cluster(s) to be deleted... (attempt ${attempts + 1}/${maxAttempts})`);
-        attempts++;
-        if (attempts >= maxAttempts) {
-          cli.output("Warning: Timeout waiting for cluster deletions. Proceeding with project deletion anyway.");
-          break;
-        }
-        sleep(1e4);
-      } catch (error) {
-        cli.output(`Warning: Error checking cluster deletion status: ${error instanceof Error ? error.message : "Unknown error"}`);
+      const remaining = this.countActiveClusters();
+      if (remaining === 0) {
+        cli.output("All clusters have been deleted successfully");
+        return;
+      }
+      cli.output(`Still waiting for ${remaining} cluster(s) to be deleted... (attempt ${attempts + 1}/${maxAttempts})`);
+      attempts++;
+      if (attempts >= maxAttempts) {
+        cli.output("Warning: Timeout waiting for cluster deletions. Proceeding with project deletion anyway.");
         break;
       }
+      sleep(1e4);
     }
   }
   /**
-   * Delete all clusters in the project before deleting the project itself
-   * This prevents the 409 error when trying to delete a project with active clusters
+   * Delete all clusters (standard + flex) in the project before deleting the project itself.
+   * This prevents the 409 CANNOT_CLOSE_GROUP_ACTIVE_ATLAS_CLUSTERS error.
    */
   deleteAllClustersInProject() {
     if (this.state.existing) {
       cli.output("Project wasn't created by this entity, skipping cluster cleanup");
       return;
     }
-    try {
-      cli.output("Checking for active clusters in project before deletion...");
-      const clustersResponse = this.makeRequest("GET", `/groups/${this.state.id}/clusters`);
-      if (clustersResponse && clustersResponse.results && clustersResponse.results.length > 0) {
-        cli.output(`Found ${clustersResponse.results.length} active cluster(s) in project. Deleting them first...`);
-        for (const cluster of clustersResponse.results) {
+    cli.output("Checking for active clusters in project before deletion...");
+    let deletedAny = false;
+    for (const collection of _Project.CLUSTER_COLLECTIONS) {
+      try {
+        const response = this.makeRequest("GET", `/groups/${this.state.id}/${collection}`);
+        const clusters = response && response.results ? response.results : [];
+        for (const cluster of clusters) {
+          deletedAny = true;
           try {
-            cli.output(`Deleting cluster: ${cluster.name}`);
-            this.makeRequest("DELETE", `/groups/${this.state.id}/clusters/${cluster.name}`);
+            cli.output(`Deleting ${collection} cluster: ${cluster.name}`);
+            this.makeRequest("DELETE", `/groups/${this.state.id}/${collection}/${cluster.name}`);
             cli.output(`Successfully deleted cluster: ${cluster.name}`);
           } catch (error) {
             cli.output(`Warning: Failed to delete cluster ${cluster.name}: ${error instanceof Error ? error.message : "Unknown error"}`);
           }
         }
-        cli.output("Waiting for cluster deletions to complete...");
-        this.waitForClusterDeletions();
-      } else {
-        cli.output("No active clusters found in project");
+      } catch (error) {
+        cli.output(`Warning: Failed to list ${collection} in project: ${error instanceof Error ? error.message : "Unknown error"}`);
       }
-    } catch (error) {
-      cli.output(`Warning: Failed to check/delete clusters in project: ${error instanceof Error ? error.message : "Unknown error"}`);
+    }
+    if (deletedAny) {
+      cli.output("Waiting for cluster deletions to complete...");
+      this.waitForClusterDeletions();
+    } else {
+      cli.output("No active clusters found in project");
     }
   }
 };
@@ -151,6 +165,11 @@ __publicField(_Project, "readiness", {
   attempts: 12
   // max attempts (12 × 10s = 2 min)
 });
+/**
+ * Cluster collections that can hold active clusters blocking group deletion.
+ * Flex clusters live under a separate endpoint from dedicated/free clusters.
+ */
+__publicField(_Project, "CLUSTER_COLLECTIONS", ["clusters", "flexClusters"]);
 var Project = _Project;
 
 

--- a/dist/mongodb-atlas/project.yaml
+++ b/dist/mongodb-atlas/project.yaml
@@ -20,7 +20,7 @@ project:
       Works with:
       - `mongodb-atlas/cluster` - Create database clusters in this project
       - `mongodb-atlas/user` - Create database users for access control
-    version-hash: 3ac5fe00117f
+    version-hash: 7c000a825997
   schema:
     secret_ref:
       type: string

--- a/dist/mongodb-atlas/user.yaml
+++ b/dist/mongodb-atlas/user.yaml
@@ -20,7 +20,7 @@ user:
       Works with:
       - `mongodb-atlas/project` - The parent project for this user
       - `mongodb-atlas/cluster` - Use this user to connect to clusters
-    version-hash: 3ac5fe00117f
+    version-hash: 7c000a825997
   schema:
     secret_ref:
       type: string

--- a/docs/superpowers/specs/2026-06-05-mongodb-atlas-flex-modernize-design.md
+++ b/docs/superpowers/specs/2026-06-05-mongodb-atlas-flex-modernize-design.md
@@ -1,0 +1,78 @@
+# mongodb-atlas: Flex support + API modernization — design
+
+**Date:** 2026-06-05
+**Status:** Approved
+
+## Problem
+
+The `mongodb-atlas` cluster entity is shipping a broken path: `instance_size` offers
+`M2`/`M5`, but those shared tiers reached End-of-Life on **2026-01-22** and the Atlas
+Admin API no longer creates them. The package also pins a 3-year-old resource version
+(`2023-01-01`) for most calls and lacks support for **Flex** clusters (the modern
+replacement for M2/M5 and serverless). Resource cleanup also emits spurious errors when a
+resource is already gone (404 `GROUP_NOT_FOUND`).
+
+## Goals
+
+1. **Correctness:** add Flex cluster support; remove dead M2/M5 tiers.
+2. **Modernize:** standardize on a single current resource version (`2025-03-12`).
+3. **Targeted base cleanup:** simplify `makeRequest`; make deletes idempotent.
+
+Non-goals: new entity types beyond Flex routing; full base rewrite to the neon/workos
+shape (those bases don't handle per-resource versioning, so a wholesale copy would
+regress Atlas).
+
+## Design
+
+### `common.ts`
+- Single version constant: `API_VERSION = "application/vnd.atlas.2025-03-12+json"`.
+  Remove the `API_VERSION_2025` dual split. `BASE_URL`, `getToken`, `getOrganization`
+  unchanged.
+
+### `atlas-base.ts`
+- `makeRequest`: always use the single 2025-03-12 media type for `Accept` and (on writes)
+  `Content-Type`. Delete the `isClusterRequest()` version switch.
+- `deleteResource`: treat HTTP 404 / errorCode `*_NOT_FOUND` / "does not exist" as success
+  (idempotent delete) via a new `isResourceGoneError()` helper. Eliminates cleanup noise
+  when the parent group is already deleted.
+- `before()`, `checkResourceExists`, `start`/`stop` unchanged.
+
+### `cluster.ts`
+- `instance_size`: `"M0" | "FLEX" | "M10" | "M20" | "M30" | "M40" | "M50" | "M60" | "M80"`
+  (M2/M5 removed).
+- `clusterPath()` helper routes by tier:
+  - **FLEX** → `POST /groups/{id}/flexClusters`, body
+    `{ name, providerSettings: { backingProviderName: provider, regionName: region } }`.
+    Get/update/delete under `/flexClusters/{name}`.
+  - **M0** → `/clusters` with `providerName: TENANT` (unchanged).
+  - **M10+** → `/clusters` dedicated (unchanged).
+- `update`/`delete`/`checkReadiness`/`checkLiveness` use `clusterPath()`. Flex GET returns
+  the same `stateName` / `connectionStrings` shape, so readiness logic is shared.
+- `validateBackupSupport()`: allow only M10+ dedicated (reject M0 and FLEX). Flex gets
+  automatic snapshots not managed by these on-demand actions.
+
+### `project.ts` / `user.ts`
+- No structural change; they now ride `2025-03-12`. Re-validate `groups` create
+  (`withDefaultAlertsSettings`) and `databaseUsers` create payloads under the new version.
+
+### Tests + docs
+- Re-run `stack-integration.test.yaml` (M0 — no extra cost) to validate version bump, base
+  refactor, and graceful delete end-to-end. Confirm the 404 cleanup noise is gone.
+- Optionally add a Flex cluster test (Flex is billable but minor) — confirm before
+  provisioning.
+- Update `README.md` instance-size table: drop M2/M5, add FLEX.
+
+## Risks
+
+- **Version bump (highest):** payload shapes for `groups`/`databaseUsers` could differ under
+  `2025-03-12`. Mitigated by the M0 integration test. Flex payload is unverified unless a
+  Flex test runs.
+- Local monkec runner requires the full `input/<pkg>/test/...` template path workaround (see
+  memory `project_monkec_test_dir_local`); not committed.
+
+## Validation checklist
+
+- [ ] `monkec compile` clean
+- [ ] `stack-integration.test.yaml` passes (M0) with no 404 cleanup noise
+- [ ] (optional) Flex test passes
+- [ ] README updated

--- a/src/mongodb-atlas/README.md
+++ b/src/mongodb-atlas/README.md
@@ -35,7 +35,7 @@ This entity allows you to:
 | **Check Status** | `monk do ns/cluster/get-restore-status job_id="xxx"` | Monitor restore progress |
 | **List Jobs** | `monk do ns/cluster/list-restore-jobs` | View all restore jobs |
 
-**Requirements:** M10+ cluster (dedicated). M0/M2/M5 shared tiers do not support backup API.
+**Requirements:** M10+ cluster (dedicated). M0 (free) and FLEX clusters do not support the on-demand backup API.
 
 **⚠️ Important:** Restore operations make the cluster **READ-ONLY** until complete.
 
@@ -108,7 +108,7 @@ interface ClusterDefinition {
   project_id: string;           // Project ID
   provider: "AWS" | "GCP" | "AZURE";  // Cloud provider
   region: string;               // Cloud region
-  instance_size: "M0" | "M2" | "M5" | "M10" | "M20" | "M30" | "M40" | "M50" | "M60" | "M80";
+  instance_size: "M0" | "FLEX" | "M10" | "M20" | "M30" | "M40" | "M50" | "M60" | "M80";
   allow_ips?: string[];         // IP addresses allowed to access
 }
 ```
@@ -242,7 +242,7 @@ MongoDB Atlas clusters (M10 and higher) support on-demand backup snapshots via c
 
 **⚠️ Important Backup Limitations:**
 - **M0 Free clusters:** No backup API support. Use `mongodump`/`mongorestore` for manual backups
-- **M2/M5 clusters:** Being migrated to Flex clusters (as of February 2025)
+- **FLEX clusters:** Replaced the retired M2/M5 shared tiers (M2/M5 reached End-of-Life 2026-01-22). Receive automatic snapshots; not managed via these on-demand actions
 - **Flex clusters:** Automatic daily snapshots (cannot be disabled)
 - **M10+ clusters:** Full Cloud Backup support with on-demand snapshots via API
 - **During restore:** Cluster becomes read-only until restore completes
@@ -553,7 +553,7 @@ The test configuration (`test/test-mongodb.yaml`) includes:
 ### Instance Sizes
 
 - **M0**: Free tier (512 MB storage, shared CPU)
-- **M2/M5**: Shared clusters
+- **FLEX**: Flex cluster — modern low-traffic tier replacing the retired M2/M5 shared clusters
 - **M10+**: Dedicated clusters with increasing resources
 
 ### Cloud Providers and Regions

--- a/src/mongodb-atlas/atlas-base.ts
+++ b/src/mongodb-atlas/atlas-base.ts
@@ -1,6 +1,6 @@
 import { MonkEntity } from "monkec/base";
 import { HttpClient } from "monkec/http-client";
-import { API_VERSION, API_VERSION_2025, BASE_URL, getToken } from "./common.ts";
+import { API_VERSION, BASE_URL, getToken } from "./common.ts";
 import cli from "cli";
 
 /**
@@ -89,17 +89,15 @@ export abstract class MongoDBAtlasEntity<
      */
     protected makeRequest(method: string, path: string, body?: any): any {
         try {
-            const apiVersion = this.isClusterRequest(path) ? API_VERSION_2025 : API_VERSION;
-            
             const headers: Record<string, string> = {
-                "Accept": apiVersion,
+                "Accept": API_VERSION,
                 "Authorization": "Bearer " + this.apiToken,
             };
-            
+
             if (method.toUpperCase() !== 'GET') {
-                headers["Content-Type"] = apiVersion;
+                headers["Content-Type"] = API_VERSION;
             }
-            
+
             const response = this.httpClient.request(method as any, path, { 
                 body,
                 headers
@@ -156,16 +154,25 @@ export abstract class MongoDBAtlasEntity<
             this.makeRequest("DELETE", path);
             cli.output(`Successfully deleted ${resourceName}`);
         } catch (error) {
+            // Idempotent delete: if the resource (or its parent group) is already gone,
+            // treat it as success rather than failing the teardown.
+            if (this.isResourceGoneError(error)) {
+                cli.output(`${resourceName} already deleted (not found), treating as success`);
+                return;
+            }
             throw new Error(`Failed to delete ${resourceName}: ${error instanceof Error ? error.message : 'Unknown error'}`);
         }
     }
 
     /**
-     * Check if the request path is for cluster operations
+     * Detect "resource already gone" errors so deletes can be idempotent.
+     * Covers HTTP 404, Atlas *_NOT_FOUND error codes, and "does not exist" messages.
      */
-    private isClusterRequest(path: string): boolean {
-        return path.includes('/clusters') || path.includes('/accessList');
+    protected isResourceGoneError(error: unknown): boolean {
+        const msg = (error instanceof Error ? error.message : String(error)).toUpperCase();
+        return msg.includes(" 404")
+            || msg.includes("NOT_FOUND")
+            || msg.includes("NOT FOUND")
+            || msg.includes("DOES NOT EXIST");
     }
-
-    
-} 
+}

--- a/src/mongodb-atlas/cluster.ts
+++ b/src/mongodb-atlas/cluster.ts
@@ -33,9 +33,11 @@ export interface ClusterDefinition extends MongoDBAtlasEntityDefinition {
     region: string;
 
     /**
-     * @description Instance size/tier
+     * @description Instance size/tier. M0 = free (shared/TENANT), FLEX = Flex cluster
+     * (replaces the retired M2/M5 shared tiers), M10+ = dedicated. M2/M5 reached
+     * End-of-Life on 2026-01-22 and are no longer creatable via the Atlas API.
      */
-    instance_size: "M0" | "M2" | "M5" | "M10" | "M20" | "M30" | "M40" | "M50" | "M60" | "M80";
+    instance_size: "M0" | "FLEX" | "M10" | "M20" | "M30" | "M40" | "M50" | "M60" | "M80";
 
     /**
      * @description Array of IP addresses allowed to access the cluster
@@ -73,7 +75,7 @@ export interface ClusterState extends MongoDBAtlasEntityState {
 /**
  * @description MongoDB Atlas Cluster entity.
  * Creates and manages MongoDB Atlas database clusters for document storage.
- * Supports M0 (free tier), M2/M5 (shared), and M10+ (dedicated) cluster tiers.
+ * Supports M0 (free tier), FLEX (Flex cluster), and M10+ (dedicated) cluster tiers.
  * 
  * ## Secrets
  * - Reads: secret name from `secret_ref` property - MongoDB Atlas service account credentials JSON
@@ -108,18 +110,67 @@ export class Cluster extends MongoDBAtlasEntity<ClusterDefinition, ClusterState>
         return this.definition.name;
     }
 
-    /**
-     * Check if the cluster tier is a shared tier (M0, M2, M5)
-     * Shared tiers use "TENANT" provider, dedicated tiers use direct provider name
-     */
-    private isSharedTier(): boolean {
-        const sharedTiers = ["M0", "M2", "M5"];
-        return sharedTiers.includes(this.definition.instance_size);
+    /** Free tier (M0) — created on the /clusters endpoint with the TENANT provider. */
+    private isFreeTier(): boolean {
+        return this.definition.instance_size === "M0";
     }
 
-    /** Create a new MongoDB Atlas cluster */
+    /** Flex tier — created on the dedicated /flexClusters endpoint. */
+    private isFlexTier(): boolean {
+        return this.definition.instance_size === "FLEX";
+    }
+
+    /** Dedicated tier (M10+) — created on the /clusters endpoint with a direct provider. */
+    private isDedicatedTier(): boolean {
+        return !this.isFreeTier() && !this.isFlexTier();
+    }
+
+    /** Collection path for this cluster's tier (Flex uses a separate endpoint). */
+    private clustersCollectionPath(): string {
+        const base = `/groups/${this.definition.project_id}`;
+        return this.isFlexTier() ? `${base}/flexClusters` : `${base}/clusters`;
+    }
+
+    /** Resource path for this specific cluster. */
+    private clusterResourcePath(): string {
+        return `${this.clustersCollectionPath()}/${this.definition.name}`;
+    }
+
+    /** Create a new MongoDB Atlas cluster (Flex, free, or dedicated). */
     override create(): void {
-        // Build region config based on cluster tier
+        if (this.isFlexTier()) {
+            this.createFlexCluster();
+        } else {
+            this.createClusterResource();
+        }
+
+        // Configure IP access list if provided (applies to all tiers)
+        if (this.definition.allow_ips && this.definition.allow_ips.length > 0) {
+            this.configureIPAccessList();
+        }
+    }
+
+    /** Create a Flex cluster via the /flexClusters endpoint. */
+    private createFlexCluster(): void {
+        const body: Record<string, unknown> = {
+            "name": this.definition.name,
+            "providerSettings": {
+                "backingProviderName": this.definition.provider,
+                "regionName": this.definition.region
+            }
+        };
+
+        const resObj = this.makeRequest("POST", this.clustersCollectionPath(), body);
+
+        this.state = {
+            // Flex clusters are identified by name; fall back to name if no id is returned.
+            id: resObj.id || resObj.name || this.definition.name,
+            name: resObj.name || this.definition.name
+        };
+    }
+
+    /** Create a free (M0/TENANT) or dedicated (M10+) cluster via the /clusters endpoint. */
+    private createClusterResource(): void {
         const regionConfig: Record<string, unknown> = {
             "electableSpecs": {
                 "instanceSize": this.definition.instance_size,
@@ -128,9 +179,8 @@ export class Cluster extends MongoDBAtlasEntity<ClusterDefinition, ClusterState>
             "regionName": this.definition.region
         };
 
-        // Shared tiers (M0, M2, M5) use TENANT provider
-        // Dedicated tiers (M10+) use direct provider name
-        if (this.isSharedTier()) {
+        // M0 (free) uses the TENANT provider; dedicated tiers use the direct provider name.
+        if (this.isFreeTier()) {
             regionConfig.providerName = "TENANT";
             regionConfig.backingProviderName = this.definition.provider;
         } else {
@@ -148,23 +198,17 @@ export class Cluster extends MongoDBAtlasEntity<ClusterDefinition, ClusterState>
             ]
         };
 
-        // Enable Cloud Backup for dedicated clusters (M10+)
-        // This is required for backup API operations
-        if (!this.isSharedTier()) {
+        // Enable Cloud Backup for dedicated clusters (M10+); required for backup API operations.
+        if (this.isDedicatedTier()) {
             body.backupEnabled = true;
         }
 
-        const resObj = this.makeRequest("POST", `/groups/${this.definition.project_id}/clusters`, body);
+        const resObj = this.makeRequest("POST", this.clustersCollectionPath(), body);
 
         this.state = {
             id: resObj.id,
             name: resObj.name
         };
-
-        // Configure IP access list if provided
-        if (this.definition.allow_ips && this.definition.allow_ips.length > 0) {
-            this.configureIPAccessList();
-        }
     }
 
     /** Configure IP access list for the cluster */
@@ -192,12 +236,12 @@ export class Cluster extends MongoDBAtlasEntity<ClusterDefinition, ClusterState>
         }
 
         // Check current cluster state
-        const clusterData = this.checkResourceExists(`/groups/${this.definition.project_id}/clusters/${this.definition.name}`);
-        
+        const clusterData = this.checkResourceExists(this.clusterResourcePath());
+
         if (clusterData) {
             this.state = {
                 ...this.state,
-                id: clusterData.id,
+                id: clusterData.id || this.state.id,
                 name: clusterData.name,
                 connection_standard: clusterData.connectionStrings?.standard,
                 connection_srv: clusterData.connectionStrings?.standardSrv
@@ -211,7 +255,7 @@ export class Cluster extends MongoDBAtlasEntity<ClusterDefinition, ClusterState>
             return;
         }
 
-        this.deleteResource(`/groups/${this.definition.project_id}/clusters/${this.definition.name}`, "Cluster");
+        this.deleteResource(this.clusterResourcePath(), "Cluster");
     }
 
     override checkReadiness(): boolean {
@@ -219,8 +263,8 @@ export class Cluster extends MongoDBAtlasEntity<ClusterDefinition, ClusterState>
             return false;
         }
 
-        const clusterData = this.checkResourceExists(`/groups/${this.definition.project_id}/clusters/${this.definition.name}`);
-        
+        const clusterData = this.checkResourceExists(this.clusterResourcePath());
+
         if (!clusterData) {
             return false;
         }
@@ -236,7 +280,7 @@ export class Cluster extends MongoDBAtlasEntity<ClusterDefinition, ClusterState>
     }
 
     override checkLiveness(): boolean {
-        const clusterData = this.checkResourceExists(`/groups/${this.definition.project_id}/clusters/${this.definition.name}`);
+        const clusterData = this.checkResourceExists(this.clusterResourcePath());
         if (!clusterData) {
             throw new Error(`Cluster ${this.definition.name} not found`);
         }
@@ -257,10 +301,11 @@ export class Cluster extends MongoDBAtlasEntity<ClusterDefinition, ClusterState>
      * Backups are only available for M10+ (dedicated) clusters
      */
     private validateBackupSupport(): void {
-        if (this.isSharedTier()) {
+        if (!this.isDedicatedTier()) {
             throw new Error(
-                `Backup operations are not supported for shared cluster tier ${this.definition.instance_size}. ` +
-                `Backups require a dedicated cluster (M10 or higher).`
+                `Backup operations are not supported for cluster tier ${this.definition.instance_size}. ` +
+                `On-demand backups require a dedicated cluster (M10 or higher). ` +
+                `Flex clusters receive automatic snapshots that are not managed via these actions.`
             );
         }
     }
@@ -297,8 +342,8 @@ export class Cluster extends MongoDBAtlasEntity<ClusterDefinition, ClusterState>
             cli.output(`   Provider: ${this.definition.provider}`);
             cli.output(`   Region: ${this.definition.region}`);
             
-            const backupSupported = !this.isSharedTier();
-            cli.output(`   Backup Supported: ${backupSupported ? '✅ Yes (M10+)' : '❌ No (shared tier)'}`);
+            const backupSupported = this.isDedicatedTier();
+            cli.output(`   Backup Supported: ${backupSupported ? '✅ Yes (M10+)' : '❌ No (M0/Flex)'}`);
             
             if (clusterData.backupEnabled !== undefined) {
                 cli.output(`   Backup Enabled: ${clusterData.backupEnabled ? '✅ Yes' : '❌ No'}`);
@@ -306,7 +351,7 @@ export class Cluster extends MongoDBAtlasEntity<ClusterDefinition, ClusterState>
             
             if (!backupSupported) {
                 cli.output(`\n⚠️  Note: Backups require a dedicated cluster (M10 or higher).`);
-                cli.output(`   Current tier ${this.definition.instance_size} is a shared tier.`);
+                cli.output(`   Current tier ${this.definition.instance_size} does not support on-demand backups.`);
             } else {
                 cli.output(`\n📋 To create a manual snapshot:`);
                 cli.output(`   monk do namespace/cluster create-snapshot`);

--- a/src/mongodb-atlas/common.ts
+++ b/src/mongodb-atlas/common.ts
@@ -3,8 +3,9 @@ import secret from "secret";
 import crypto from "crypto";
 
 export const BASE_URL = "https://cloud.mongodb.com/api/atlas/v2";
-export const API_VERSION = "application/vnd.atlas.2023-01-01+json";
-export const API_VERSION_2025 = "application/vnd.atlas.2025-03-12+json";
+// Single pinned resource version for all endpoints. 2025-03-12 is the current
+// version and is required for Flex cluster endpoints (introduced 2024-11-13).
+export const API_VERSION = "application/vnd.atlas.2025-03-12+json";
 
 /**
  * Get MongoDB Atlas OAuth2 Bearer token from service account credentials

--- a/src/mongodb-atlas/project.ts
+++ b/src/mongodb-atlas/project.ts
@@ -173,45 +173,58 @@ export class Project extends MongoDBAtlasEntity<ProjectDefinition, ProjectState>
     }
 
     /**
-     * Wait for all cluster deletions to complete by polling the API
+     * Cluster collections that can hold active clusters blocking group deletion.
+     * Flex clusters live under a separate endpoint from dedicated/free clusters.
+     */
+    private static readonly CLUSTER_COLLECTIONS = ["clusters", "flexClusters"];
+
+    /**
+     * Count active clusters across both the standard and flex endpoints.
+     */
+    private countActiveClusters(): number {
+        let total = 0;
+        for (const collection of Project.CLUSTER_COLLECTIONS) {
+            try {
+                const response = this.makeRequest("GET", `/groups/${this.state.id}/${collection}`);
+                if (response && response.results) {
+                    total += response.results.length;
+                }
+            } catch (_error) {
+                // Endpoint may be unavailable; ignore and rely on the other collection.
+            }
+        }
+        return total;
+    }
+
+    /**
+     * Wait for all cluster deletions (standard + flex) to complete by polling the API
      */
     private waitForClusterDeletions(): void {
         const maxAttempts = 30; // Wait up to 5 minutes (30 * 10 seconds)
         let attempts = 0;
-        
+
         while (attempts < maxAttempts) {
-            try {
-                const clustersResponse = this.makeRequest("GET", `/groups/${this.state.id}/clusters`);
-                
-                if (!clustersResponse || !clustersResponse.results || clustersResponse.results.length === 0) {
-                    cli.output("All clusters have been deleted successfully");
-                    return;
-                }
-                
-                const remainingClusters = clustersResponse.results.length;
-                cli.output(`Still waiting for ${remainingClusters} cluster(s) to be deleted... (attempt ${attempts + 1}/${maxAttempts})`);
-                
-                // Wait 10 seconds before next check
-                // Note: In Goja runtime, we don't have setTimeout, so we'll use a simple delay
-                attempts++;
-                
-                if (attempts >= maxAttempts) {
-                    cli.output("Warning: Timeout waiting for cluster deletions. Proceeding with project deletion anyway.");
-                    break;
-                }
-                
-                sleep(10000);
-                
-            } catch (error) {
-                cli.output(`Warning: Error checking cluster deletion status: ${error instanceof Error ? error.message : 'Unknown error'}`);
+            const remaining = this.countActiveClusters();
+            if (remaining === 0) {
+                cli.output("All clusters have been deleted successfully");
+                return;
+            }
+
+            cli.output(`Still waiting for ${remaining} cluster(s) to be deleted... (attempt ${attempts + 1}/${maxAttempts})`);
+            attempts++;
+
+            if (attempts >= maxAttempts) {
+                cli.output("Warning: Timeout waiting for cluster deletions. Proceeding with project deletion anyway.");
                 break;
             }
+
+            sleep(10000);
         }
     }
 
     /**
-     * Delete all clusters in the project before deleting the project itself
-     * This prevents the 409 error when trying to delete a project with active clusters
+     * Delete all clusters (standard + flex) in the project before deleting the project itself.
+     * This prevents the 409 CANNOT_CLOSE_GROUP_ACTIVE_ATLAS_CLUSTERS error.
      */
     private deleteAllClustersInProject(): void {
         if (this.state.existing) {
@@ -219,36 +232,36 @@ export class Project extends MongoDBAtlasEntity<ProjectDefinition, ProjectState>
             return;
         }
 
-        try {
-            cli.output("Checking for active clusters in project before deletion...");
-            
-            // Get all clusters in the project
-            const clustersResponse = this.makeRequest("GET", `/groups/${this.state.id}/clusters`);
-            
-            if (clustersResponse && clustersResponse.results && clustersResponse.results.length > 0) {
-                cli.output(`Found ${clustersResponse.results.length} active cluster(s) in project. Deleting them first...`);
-                
-                // Delete each cluster
-                for (const cluster of clustersResponse.results) {
+        cli.output("Checking for active clusters in project before deletion...");
+        let deletedAny = false;
+
+        for (const collection of Project.CLUSTER_COLLECTIONS) {
+            try {
+                const response = this.makeRequest("GET", `/groups/${this.state.id}/${collection}`);
+                const clusters = (response && response.results) ? response.results : [];
+
+                for (const cluster of clusters) {
+                    deletedAny = true;
                     try {
-                        cli.output(`Deleting cluster: ${cluster.name}`);
-                        this.makeRequest("DELETE", `/groups/${this.state.id}/clusters/${cluster.name}`);
+                        cli.output(`Deleting ${collection} cluster: ${cluster.name}`);
+                        this.makeRequest("DELETE", `/groups/${this.state.id}/${collection}/${cluster.name}`);
                         cli.output(`Successfully deleted cluster: ${cluster.name}`);
                     } catch (error) {
                         cli.output(`Warning: Failed to delete cluster ${cluster.name}: ${error instanceof Error ? error.message : 'Unknown error'}`);
                         // Continue with other clusters even if one fails
                     }
                 }
-                
-                // Wait for cluster deletions to complete by polling
-                cli.output("Waiting for cluster deletions to complete...");
-                this.waitForClusterDeletions();
-            } else {
-                cli.output("No active clusters found in project");
+            } catch (error) {
+                cli.output(`Warning: Failed to list ${collection} in project: ${error instanceof Error ? error.message : 'Unknown error'}`);
+                // Continue with the other collection / project deletion attempt
             }
-        } catch (error) {
-            cli.output(`Warning: Failed to check/delete clusters in project: ${error instanceof Error ? error.message : 'Unknown error'}`);
-            // Continue with project deletion attempt even if cluster cleanup fails
+        }
+
+        if (deletedAny) {
+            cli.output("Waiting for cluster deletions to complete...");
+            this.waitForClusterDeletions();
+        } else {
+            cli.output("No active clusters found in project");
         }
     }
 }

--- a/src/mongodb-atlas/test/backup-integration.test.yaml
+++ b/src/mongodb-atlas/test/backup-integration.test.yaml
@@ -3,7 +3,7 @@ description: "Integration test for MongoDB Atlas backup operations using standar
 timeout: 1200000
 
 # NOTE: This test requires a dedicated cluster (M10 or higher) to run backup operations.
-# Shared tier clusters (M0, M2, M5) do not support the backup API.
+# M0 (free) and FLEX clusters do not support the on-demand backup API.
 
 secrets:
   global:


### PR DESCRIPTION
## Summary
- The cluster entity offered **M2/M5** shared tiers, which reached End-of-Life on 2026-01-22 and are no longer creatable via the Atlas Admin API — a broken path. This adds **Flex** support (the modern replacement), standardizes on the current **2025-03-12** resource version, and makes resource deletion idempotent.
- Surfaced and fixed a Flex-specific teardown bug: the project's pre-delete cluster sweep didn't know about `/flexClusters`, causing a 409 when closing a group that still held a Flex cluster.

## Changes
**Entity code**
- `cluster.ts` — drop M2/M5 from `instance_size`; add **FLEX** routing via `clusterPath()` (FLEX→`/flexClusters`, M0→TENANT, M10+→dedicated); backup actions now require a dedicated tier
- `project.ts` — pre-delete cluster sweep now drains both `/clusters` **and** `/flexClusters`, preventing `409 CANNOT_CLOSE_GROUP_ACTIVE_ATLAS_CLUSTERS`
- `atlas-base.ts` — single `2025-03-12` media type (removed per-path version switch); `deleteResource` treats 404 / `*_NOT_FOUND` as success (idempotent delete)
- `common.ts` — single `API_VERSION` pinned to `2025-03-12`

**Docs / tests**
- `README.md` — instance-size docs updated (M0 / FLEX / M10+)
- `docs/superpowers/specs/` — design spec
- `test/backup-integration.test.yaml` — stale tier comment fixed

**Build**
- `dist/mongodb-atlas/` regenerated

## Test plan
- [x] `monkec compile` clean
- [x] M0 lifecycle integration test — 9/9 (validates 2025-03-12 bump for project/user/cluster, graceful delete)
- [x] Flex lifecycle integration test — 9/9 (create → readiness → live mongosh connect → delete; flex-aware project teardown, no orphan)
- [x] Graceful delete: 404/`GROUP_NOT_FOUND` no longer thrown
- [ ] M10 backup actions: not exercised — M10 readiness timed out provisioning (environmental, not a regression); backup actions are unchanged by this work apart from the tier guard

## Notes
- No M2/M5 values remain in any loadable YAML.
- All test resources cleaned up; no orphans left on the Atlas org.