### PR TITLE
fix(vercel): remove obsolete --public flag; bump default Node to 24 for vercel/netlify

### DIFF
--- a/netlify/Dockerfile
+++ b/netlify/Dockerfile
@@ -1,4 +1,4 @@
-ARG NODE_VERSION=20
+ARG NODE_VERSION=24
 FROM node:${NODE_VERSION}-alpine
 
 RUN npm install netlify-cli -g

--- a/netlify/build-image.sh
+++ b/netlify/build-image.sh
@@ -23,3 +23,9 @@ podman manifest rm monkimages.azurecr.io/netlify-build:24
 podman manifest create monkimages.azurecr.io/netlify-build:24
 podman build --build-arg NODE_VERSION=24 --platform linux/amd64,linux/arm64 --manifest monkimages.azurecr.io/netlify-build:24 .
 podman manifest push monkimages.azurecr.io/netlify-build:24
+
+podman rmi monkimages.azurecr.io/netlify-build:26
+podman manifest rm monkimages.azurecr.io/netlify-build:26
+podman manifest create monkimages.azurecr.io/netlify-build:26
+podman build --build-arg NODE_VERSION=26 --platform linux/amd64,linux/arm64 --manifest monkimages.azurecr.io/netlify-build:26 .
+podman manifest push monkimages.azurecr.io/netlify-build:26

--- a/netlify/netlify.yaml
+++ b/netlify/netlify.yaml
@@ -25,8 +25,8 @@ deploy:
     node-version:
       env: NODE_VERSION
       type: string
-      value: 20
-      description: The Node.js version to use for the build environment. One of 18, 20, 22, 24. Pick node version based on the project requirements, or leave unset for default (20).
+      value: 24
+      description: The Node.js version to use for the build environment. One of 18, 20, 22, 24, 26. Pick node version based on the project requirements, or leave unset for default (24).
     site-id:
       env: NETLIFY_SITE_ID
       type: string

--- a/vercel/Dockerfile
+++ b/vercel/Dockerfile
@@ -10,4 +10,4 @@ USER node
 
 ENV VERCEL_TOKEN=""
 
-CMD ["sh", "-c", "vercel deploy --prod --public --yes -t $VERCEL_TOKEN"]
+CMD ["sh", "-c", "vercel deploy --prod --yes -t $VERCEL_TOKEN"]

--- a/vercel/Dockerfile
+++ b/vercel/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:20-alpine
+ARG NODE_VERSION=24
+FROM node:${NODE_VERSION}-alpine
 
 RUN npm i -g vercel
 

--- a/vercel/build-image.sh
+++ b/vercel/build-image.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+podman rmi monkimages.azurecr.io/vercel-build:18
+podman manifest rm monkimages.azurecr.io/vercel-build:18
+podman manifest create monkimages.azurecr.io/vercel-build:18
+podman build --build-arg NODE_VERSION=18 --platform linux/amd64,linux/arm64 --manifest monkimages.azurecr.io/vercel-build:18 .
+podman manifest push monkimages.azurecr.io/vercel-build:18
+
+podman rmi monkimages.azurecr.io/vercel-build:20
+podman manifest rm monkimages.azurecr.io/vercel-build:20
+podman manifest create monkimages.azurecr.io/vercel-build:20
+podman build --build-arg NODE_VERSION=20 --platform linux/amd64,linux/arm64 --manifest monkimages.azurecr.io/vercel-build:20 .
+podman manifest push monkimages.azurecr.io/vercel-build:20
+
+podman rmi monkimages.azurecr.io/vercel-build:22
+podman manifest rm monkimages.azurecr.io/vercel-build:22
+podman manifest create monkimages.azurecr.io/vercel-build:22
+podman build --build-arg NODE_VERSION=22 --platform linux/amd64,linux/arm64 --manifest monkimages.azurecr.io/vercel-build:22 .
+podman manifest push monkimages.azurecr.io/vercel-build:22
+
+podman rmi monkimages.azurecr.io/vercel-build:24
+podman manifest rm monkimages.azurecr.io/vercel-build:24
+podman manifest create monkimages.azurecr.io/vercel-build:24
+podman build --build-arg NODE_VERSION=24 --platform linux/amd64,linux/arm64 --manifest monkimages.azurecr.io/vercel-build:24 .
+podman manifest push monkimages.azurecr.io/vercel-build:24
+
+podman rmi monkimages.azurecr.io/vercel-build:26
+podman manifest rm monkimages.azurecr.io/vercel-build:26
+podman manifest create monkimages.azurecr.io/vercel-build:26
+podman build --build-arg NODE_VERSION=26 --platform linux/amd64,linux/arm64 --manifest monkimages.azurecr.io/vercel-build:26 .
+podman manifest push monkimages.azurecr.io/vercel-build:26

--- a/vercel/vercel.yaml
+++ b/vercel/vercel.yaml
@@ -6,7 +6,8 @@ deploy:
     default-vercel-token: true
   containers:
     deploy:
-      image: monkimages.azurecr.io/example-vercel-build:latest
+      image: monkimages.azurecr.io/vercel-build
+      image-tag: <- $node-version
       restart: no
       bash: /tmp/init.sh
 #      paths:
@@ -22,6 +23,11 @@ deploy:
         vercel link --cwd $DEPLOY_DIR --yes --project $VERCEL_PROJECT -t $VERCEL_TOKEN
         echo "y\n" | vercel deploy --cwd $DEPLOY_DIR --prod --yes -t $VERCEL_TOKEN
   variables:
+    node-version:
+      env: NODE_VERSION
+      type: string
+      value: 24
+      description: The Node.js version to use for the build environment. One of 18, 20, 22, 24, 26. Pick node version based on the project requirements, or leave unset for default (24).
     project:
       env: VERCEL_PROJECT
       type: string

--- a/vercel/vercel.yaml
+++ b/vercel/vercel.yaml
@@ -20,7 +20,7 @@ deploy:
         #!/bin/sh
         {{ v "pre-deploy" }}
         vercel link --cwd $DEPLOY_DIR --yes --project $VERCEL_PROJECT -t $VERCEL_TOKEN
-        echo "y\n" | vercel deploy --cwd $DEPLOY_DIR --prod --public --yes -t $VERCEL_TOKEN
+        echo "y\n" | vercel deploy --cwd $DEPLOY_DIR --prod --yes -t $VERCEL_TOKEN
   variables:
     project:
       env: VERCEL_PROJECT


### PR DESCRIPTION
## Fix: obsolete --public flag (PRO-857)

`vercel/deploy` hardcoded an obsolete `--public` option:

```
vercel deploy --cwd $DEPLOY_DIR --prod --public --yes -t $VERCEL_TOKEN
```

Current Vercel CLI/API rejects this before upload/build:

```
Error: Invalid vercel.json - should NOT have additional property `public`. Please remove it.
```

Repro'd against a real Next.js app deployed through `monk.project.deploy` (Monk plugin 0.1.57,
Monk CLI/daemon 3.21.2, Vercel CLI 54.4.1). Removed `--public` from both the runnable's deploy
command and the standalone Docker image's default `CMD`, so they stay in sync.

Fixes PRO-857.

## Also: bump default Node version to 24, add missing vercel build-image.sh

- Default `node-version` for both `netlify/deploy` and `vercel/deploy` moves from 20 to 24
  (current Node LTS); 26 is now listed as a selectable version alongside 18/20/22/24.
- `vercel/Dockerfile` now takes `NODE_VERSION` as a build arg (`ARG NODE_VERSION=24` /
  `FROM node:${NODE_VERSION}-alpine`), mirroring `netlify/Dockerfile`, instead of hardcoding
  `node:20-alpine`.
- `vercel/vercel.yaml` gains a `node-version` variable and switches the container to
  `image` + `image-tag` (same pattern as netlify) so callers can pick 18/20/22/24/26 per
  project instead of always getting a static image.
- Added `vercel/build-image.sh` (was missing entirely) to build/push the versioned
  `monkimages.azurecr.io/vercel-build:<version>` manifests, mirroring
  `netlify/build-image.sh`. Renamed the image from `example-vercel-build` to `vercel-build`
  to match the `netlify-build` naming convention.
- Added a `netlify-build:26` entry to `netlify/build-image.sh`.

### ⚠️ Rollout note

`vercel.yaml` now resolves its container's `image-tag` from `node-version` instead of a
static `:latest` tag. **The `vercel-build:18/20/22/24/26` images must be built and pushed
to `monkimages.azurecr.io` via `vercel/build-image.sh` before/at merge time**, or the
`vercel/deploy` runnable will fail to pull an image.

Supersedes #218 (closed in favor of this combined PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)