### PR TITLE
fix(vercel,netlify): stop publishing empty manifest lists in build-image.sh

### DIFF
--- a/netlify/build-image.sh
+++ b/netlify/build-image.sh
@@ -1,31 +1,22 @@
 #!/bin/bash
+set -euo pipefail
 
-podman rmi monkimages.azurecr.io/netlify-build:18
-podman manifest rm monkimages.azurecr.io/netlify-build:18
-podman manifest create monkimages.azurecr.io/netlify-build:18
-podman build --build-arg NODE_VERSION=18 --platform linux/amd64,linux/arm64 --manifest monkimages.azurecr.io/netlify-build:18 .
-podman manifest push monkimages.azurecr.io/netlify-build:18
+IMAGE=monkimages.azurecr.io/netlify-build
+VERSIONS=(18 20 22 24 26)
 
-podman rmi monkimages.azurecr.io/netlify-build:20
-podman manifest rm monkimages.azurecr.io/netlify-build:20
-podman manifest create monkimages.azurecr.io/netlify-build:20
-podman build --build-arg NODE_VERSION=20 --platform linux/amd64,linux/arm64 --manifest monkimages.azurecr.io/netlify-build:20 .
-podman manifest push monkimages.azurecr.io/netlify-build:20
+for version in "${VERSIONS[@]}"; do
+  tag="$IMAGE:$version"
 
-podman rmi monkimages.azurecr.io/netlify-build:22
-podman manifest rm monkimages.azurecr.io/netlify-build:22
-podman manifest create monkimages.azurecr.io/netlify-build:22
-podman build --build-arg NODE_VERSION=22 --platform linux/amd64,linux/arm64 --manifest monkimages.azurecr.io/netlify-build:22 .
-podman manifest push monkimages.azurecr.io/netlify-build:22
+  podman rmi "$tag" 2>/dev/null || true
+  podman manifest rm "$tag" 2>/dev/null || true
+  podman manifest create "$tag"
+  podman build --build-arg NODE_VERSION="$version" --platform linux/amd64,linux/arm64 --manifest "$tag" .
 
-podman rmi monkimages.azurecr.io/netlify-build:24
-podman manifest rm monkimages.azurecr.io/netlify-build:24
-podman manifest create monkimages.azurecr.io/netlify-build:24
-podman build --build-arg NODE_VERSION=24 --platform linux/amd64,linux/arm64 --manifest monkimages.azurecr.io/netlify-build:24 .
-podman manifest push monkimages.azurecr.io/netlify-build:24
+  count=$(podman manifest inspect "$tag" | grep -c '"platform"')
+  if [ "$count" -eq 0 ]; then
+    echo "refusing to push $tag: local manifest has zero platform entries" >&2
+    exit 1
+  fi
 
-podman rmi monkimages.azurecr.io/netlify-build:26
-podman manifest rm monkimages.azurecr.io/netlify-build:26
-podman manifest create monkimages.azurecr.io/netlify-build:26
-podman build --build-arg NODE_VERSION=26 --platform linux/amd64,linux/arm64 --manifest monkimages.azurecr.io/netlify-build:26 .
-podman manifest push monkimages.azurecr.io/netlify-build:26
+  podman manifest push "$tag"
+done

--- a/vercel/build-image.sh
+++ b/vercel/build-image.sh
@@ -1,31 +1,22 @@
 #!/bin/bash
+set -euo pipefail
 
-podman rmi monkimages.azurecr.io/vercel-build:18
-podman manifest rm monkimages.azurecr.io/vercel-build:18
-podman manifest create monkimages.azurecr.io/vercel-build:18
-podman build --build-arg NODE_VERSION=18 --platform linux/amd64,linux/arm64 --manifest monkimages.azurecr.io/vercel-build:18 .
-podman manifest push monkimages.azurecr.io/vercel-build:18
+IMAGE=monkimages.azurecr.io/vercel-build
+VERSIONS=(18 20 22 24 26)
 
-podman rmi monkimages.azurecr.io/vercel-build:20
-podman manifest rm monkimages.azurecr.io/vercel-build:20
-podman manifest create monkimages.azurecr.io/vercel-build:20
-podman build --build-arg NODE_VERSION=20 --platform linux/amd64,linux/arm64 --manifest monkimages.azurecr.io/vercel-build:20 .
-podman manifest push monkimages.azurecr.io/vercel-build:20
+for version in "${VERSIONS[@]}"; do
+  tag="$IMAGE:$version"
 
-podman rmi monkimages.azurecr.io/vercel-build:22
-podman manifest rm monkimages.azurecr.io/vercel-build:22
-podman manifest create monkimages.azurecr.io/vercel-build:22
-podman build --build-arg NODE_VERSION=22 --platform linux/amd64,linux/arm64 --manifest monkimages.azurecr.io/vercel-build:22 .
-podman manifest push monkimages.azurecr.io/vercel-build:22
+  podman rmi "$tag" 2>/dev/null || true
+  podman manifest rm "$tag" 2>/dev/null || true
+  podman manifest create "$tag"
+  podman build --build-arg NODE_VERSION="$version" --platform linux/amd64,linux/arm64 --manifest "$tag" .
 
-podman rmi monkimages.azurecr.io/vercel-build:24
-podman manifest rm monkimages.azurecr.io/vercel-build:24
-podman manifest create monkimages.azurecr.io/vercel-build:24
-podman build --build-arg NODE_VERSION=24 --platform linux/amd64,linux/arm64 --manifest monkimages.azurecr.io/vercel-build:24 .
-podman manifest push monkimages.azurecr.io/vercel-build:24
+  count=$(podman manifest inspect "$tag" | grep -c '"platform"')
+  if [ "$count" -eq 0 ]; then
+    echo "refusing to push $tag: local manifest has zero platform entries" >&2
+    exit 1
+  fi
 
-podman rmi monkimages.azurecr.io/vercel-build:26
-podman manifest rm monkimages.azurecr.io/vercel-build:26
-podman manifest create monkimages.azurecr.io/vercel-build:26
-podman build --build-arg NODE_VERSION=26 --platform linux/amd64,linux/arm64 --manifest monkimages.azurecr.io/vercel-build:26 .
-podman manifest push monkimages.azurecr.io/vercel-build:26
+  podman manifest push "$tag"
+done


### PR DESCRIPTION
## Problem (PRO-859, High)

`monkimages.azurecr.io/vercel-build:24` and `:26` are published as manifest lists
with **zero platform entries** — every pull fails, on every platform (arm64 local
Mac deploys, amd64 cluster deploys alike). Since #217 made `node-version: 24` the
default for `vercel/deploy`, every Vercel deploy through Monk hits this immediately.

Root cause: `vercel/build-image.sh` had no `set -e`. When the per-platform
`podman build --manifest ...` step failed for a tag, the empty manifest created a
line earlier (`podman manifest create`) was still pushed as-is, silently
publishing a tag that resolves to no platform.

## Fix

`vercel/build-image.sh`, `netlify/build-image.sh`: add `set -euo pipefail`, and
refuse to `podman manifest push` a tag whose local `podman manifest inspect`
shows zero `"platform"` entries.

`vercel.yaml`'s default `node-version` stays at 24 — no rollback here.

## Still needed (can't do from here)

Someone with `AcrPush` on `monkimages.azurecr.io` needs to run the hardened
`vercel/build-image.sh` to actually fix the `:24`/`:26` tags in the registry —
the credentials available during triage were pull-only.

Fixes PRO-859.

🤖 Generated with [Claude Code](https://claude.com/claude-code)